### PR TITLE
Platform-neutral docs; add /audit, /sync-check, /plan-new

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,69 @@
+---
+description: Scan the life-atlas repo for drift, empty stubs, broken cross-references, and legacy references
+---
+
+# /audit
+
+Scan the life-atlas repo for drift.
+
+## What to check
+
+1. **Empty or near-empty files** — any `.md` or `.sh` file under 100 bytes that isn't a legitimate stub (stubs have a header + TODO list). Flag with path and size.
+
+2. **TODO-only stubs** — files with a `**Status:** pending` header. Report as informational (they're intentional), but flag if the repo's age suggests they should be filled by now.
+
+3. **Broken cross-references** — markdown links `](path)` to other files in the repo that don't exist. Use Grep with pattern `\]\([^http][^)]+\)` in `.md` files; verify each target exists.
+
+4. **README vs filesystem drift** — paths mentioned in `README.md` folder trees vs what actually exists in the repo. Flag missing files and orphans.
+
+5. **Legacy concept references** — Grep across the repo for `Kit/`, `LiveDocs/`, `~/Vault/` (these were earlier designs). Flag matches in any `.md` or `.sh` file that isn't a `CHANGELOG` or history record.
+
+6. **Editor / OS cruft in the working tree** — `.DS_Store`, `Thumbs.db`, `*.swp` that `.gitignore` should catch. Use `git status --short --ignored` to see what's on disk but ignored, and `git ls-files` for tracked.
+
+## How to run
+
+Parallelize where possible. Each check is independent:
+
+- Glob `**/*.md` and `**/*.sh` — get the candidate set
+- Use Bash `wc -c` on each for size (or batch with `find` / `stat`)
+- Grep for legacy terms: `Kit/|LiveDocs/|~/Vault/`
+- Grep for broken-link patterns
+- Run `git status --short` for cruft check
+
+## Report format
+
+Single summary, grouped by severity:
+
+```
+Audit: life-atlas
+
+🚨 Broken cross-references (N):
+  - CLAUDE.md:42 → ../missing.md
+  - README.md:88 → device-schemas/typo.md
+
+⚠️  Legacy references (N):
+  - some-file.md:12 → "Kit/"
+
+ℹ️  TODO stubs (N) — intentional:
+  - environment/defaults_settings.sh
+  - environment/devtools.sh
+  ...
+
+ℹ️  Empty / near-empty files (N):
+  - none
+
+ℹ️  Cruft in working tree (N):
+  - none
+
+Recommendations:
+  - Fix broken links in CLAUDE.md:42 and README.md:88
+  - Legacy "Kit/" reference in some-file.md is likely stale — update to Atlas language
+```
+
+Keep the output focused. Don't list every clean file; list violations.
+
+## When to run
+
+- At the start of a session (optional — session-start can call it on demand)
+- Before a major commit to verify nothing drifted
+- When the repo "feels off"

--- a/.claude/commands/plan-new.md
+++ b/.claude/commands/plan-new.md
@@ -1,0 +1,98 @@
+---
+description: Scaffold a new plan file in docs/plans/ using the life-atlas plan template
+---
+
+# /plan-new
+
+Scaffold a new plan file in `docs/plans/`.
+
+## Usage
+
+```
+/plan-new <short-name> "<title>"
+```
+
+Example:
+
+```
+/plan-new macos-init-rewrite "Rewrite macos_environment_init.sh for Atlas model"
+```
+
+## What it does
+
+1. Glob `docs/plans/*.md` to find the next available plan number (ignore `README.md` and `archive/`). Number format: four digits, zero-padded.
+2. Compute filename: `docs/plans/NNNN-<short-name>.md`.
+3. Write the template below, substituting `<title>`, `NNNN`, and today's date.
+4. Print the path for the user.
+
+## Template
+
+```markdown
+# Plan NNNN — <title>
+
+**Status:** Draft
+**Issue:** #N (if applicable)
+**Created:** YYYY-MM-DD
+
+---
+
+## Goal
+
+One paragraph: what we're trying to accomplish and why it matters.
+
+## Scope
+
+- **In:** what's part of this plan
+- **Out:** explicitly not part of this plan
+
+## Approach
+
+Phased breakdown. Each phase has a goal and exit criteria.
+
+### Phase 1 — <name>
+
+**Goal:** ...
+
+**Steps:**
+1. ...
+2. ...
+
+**Exit criteria:** how we know this phase is done.
+
+### Phase 2 — <name>
+
+...
+
+## Risks
+
+- What could go wrong
+- What we'd need to revisit
+
+## Open questions
+
+- Things we don't know yet
+- Decisions to make before starting
+
+## Status log
+
+- YYYY-MM-DD — Plan drafted
+```
+
+## Status markers
+
+The `Status:` line in the header drives session-start behavior:
+
+- `Draft` — written but not active
+- `In Progress` — session-start will surface it
+- `Complete` — work done; keep for reference
+- `Abandoned` — decided not to pursue; keep for history
+
+Session-start searches for `In Progress` or `🚧` in the first few lines.
+
+## After scaffolding
+
+Remind the user to:
+
+1. Fill in the Goal and Scope
+2. Link the related GitHub issue (if any) in the header
+3. Flip `Status: Draft` → `Status: In Progress` when starting execution

--- a/.claude/commands/sync-check.md
+++ b/.claude/commands/sync-check.md
@@ -1,0 +1,89 @@
+---
+description: Verify the on-disk filesystem on this workstation matches what life-atlas schemas describe
+---
+
+# /sync-check
+
+Verify the on-disk reality matches what life-atlas documents.
+
+Life-atlas describes *target* structure. Actual filesystem state can drift. This command checks, without touching user data.
+
+## What to check
+
+1. **Cloud drive root** — does the described cloud-drive mount path exist? (Reference: `~/Atlas/`.)
+
+2. **Cloud drive subfolders** — from README's folder tree, which described subfolders exist at the cloud drive root? Missing ones are flagged.
+
+3. **Local outside-Atlas paths** — do described local paths exist? (Reference: `~/workspace/`, `~/Pictures/`.)
+
+4. **NAS mount** — does the described NAS mount path exist? (Reference: `/Volumes/personal_folder/Atlas`.)
+
+5. **Legacy paths** — does `~/System/`, `~/Kit/`, or any `~/*-Example/` directory exist? These are legacy / leftover and flagged for cleanup.
+
+6. **Repo's own expected paths** — is `docs/` present (session scratch location)? Is `.claude/skills/` populated?
+
+## How to run
+
+Use `Bash` for filesystem existence checks. **Do not `ls` contents or Read files inside user data paths** — only check for directory existence.
+
+Parallelize checks (one Bash call per path):
+
+```bash
+test -d ~/Atlas && echo "✓ ~/Atlas" || echo "✗ ~/Atlas (MISSING)"
+test -d ~/Atlas/config && echo "✓ ~/Atlas/config" || echo "✗ ~/Atlas/config"
+test -d ~/Atlas/docs && echo "✓ ~/Atlas/docs" || echo "✗ ~/Atlas/docs"
+# ... etc
+```
+
+For legacy paths, presence is a **warning**:
+
+```bash
+test -d ~/System && echo "⚠ ~/System (legacy; issue #5)"
+test -d ~/Kit && echo "⚠ ~/Kit (pre-Atlas; should not exist)"
+```
+
+## Report format
+
+```
+Sync-check: reference implementation
+
+Cloud drive root:
+  ✓ ~/Atlas/
+  ✓ ~/Atlas/archive/
+  ✓ ~/Atlas/config/
+  ✓ ~/Atlas/docs/
+  ✗ ~/Atlas/share/     (missing; README lists this)
+
+Outside Atlas:
+  ✓ ~/workspace/
+  ✓ ~/Pictures/
+
+NAS:
+  ✓ /Volumes/personal_folder/Atlas
+
+Legacy:
+  ⚠ ~/System/                   (legacy; GH issue #5)
+  ⚠ ~/Atlas-Example-Aliases.txt (leftover from init-script; GH issue #1)
+
+Repo infra:
+  ✓ docs/
+  ✓ .claude/skills/
+
+Summary: 1 missing (Atlas/share), 2 legacy warnings.
+
+Recommendations:
+  - Create ~/Atlas/share/ in Google Drive, or update README if intentionally absent
+  - Clean up ~/Atlas-Example-Aliases.txt (issue #1 covers the rewrite)
+```
+
+## When to run
+
+- After setting up a new device
+- When `/audit` or conversation suggests drift between docs and reality
+- Before starting work that assumes the described structure
+
+## Do NOT
+
+- Don't list contents of `~/Atlas/` or any subfolder — that's user data
+- Don't Read files inside the cloud drive or NAS mount
+- Don't create missing folders without explicit user approval (just report)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,44 @@
 # Life Atlas — Project Guide
 
-This repo documents and automates the **Atlas system** — a personal digital-organization structure spanning Google Drive, local Macs, and a home NAS.
+This repo documents and automates a personal digital-organization system called **Atlas** — a cross-device pattern for keeping important documents, cross-device config, shareable material, and daily working state organized across desktops, laptops, phones, tablets, and network storage.
 
 ---
 
-## What Atlas is
+## The Atlas pattern (abstract)
 
-**Atlas** is a Google Drive folder (`~/Atlas/` on Mac) that holds important documents, cross-device config, and shareable material. It syncs three ways:
+Atlas is a set of folder and sync conventions that span these roles:
 
-- **Cloud:** Google Drive (primary source of truth)
-- **Mac:** `~/Atlas/` via Google Drive desktop app
-- **NAS:** `/Volumes/personal_folder/Atlas` on NAS named `Peddocks2` (backup mirror)
+- **Canonical cloud drive folder** — source of truth for important documents, cross-device config, and shareable material. Accessible from any device with a browser or cloud app.
+- **Primary workstation** — laptop or desktop where most active work happens. Atlas is mirrored locally; code and large media live in separate local paths.
+- **Secondary workstation** — additional desktop (different OS or role, e.g., GPU work).
+- **Company workstation** — work-issued device, subject to company policy. Personal Atlas is NOT synced here.
+- **Network-attached storage (NAS)** — local-network backup of the cloud folder, Time Machine target, and shared media library host.
+- **Mobile devices (phones, tablets)** — read-often access to Atlas via native cloud apps; capture surface for shortcuts, quick notes, travel documents.
 
-The `life-atlas` repo contains **documentation and setup scripts about Atlas — not Atlas data itself.** Never commit personal documents, identity docs, keys, or anything from `~/Atlas/docs/` or `~/Atlas/config/keys/` into this repo.
+The pattern's purpose is comprehensive: **one mental model for where anything lives, regardless of which device is at hand.**
 
 ---
 
-## Ground-truth structure of `~/Atlas/`
+## Reference implementation (this user's setup)
+
+The pattern is implementation-agnostic. This user's concrete choices:
+
+| Pattern role | Reference implementation |
+|---|---|
+| Canonical cloud drive | Google Drive, mounted at `~/Atlas/` |
+| Primary workstation | MacBook Pro (personal, macOS) |
+| Secondary workstation | Personal PC (Windows 11 Pro, NVIDIA RTX 5080) |
+| Company workstation | MacBook Pro (work, macOS) |
+| Network-attached storage | UGREEN NAS named `Peddocks2` at `/Volumes/personal_folder/Atlas` |
+| Phone | iPhone 16 Pro (Google Drive iOS app) |
+| Tablet | iPad 2024 (Google Drive iOS app) |
+| Consulting cloud | Separate Syntheus Google Drive |
+
+**Language rule:** when docs describe the *pattern*, use abstract terms ("cloud drive folder," "primary workstation," "NAS," "mobile device"). When describing the *reference implementation*, specific names are fine. Device-schema files name specific devices because they ARE specific; that's expected.
+
+---
+
+## Ground-truth structure of the cloud drive folder
 
 ```
 ~/Atlas/
@@ -24,37 +46,39 @@ The `life-atlas` repo contains **documentation and setup scripts about Atlas —
 ├── config/     # Cross-device config (ai, apps, desktop-images, keys,
 │               # settings, shortcuts, templates, themes)
 ├── docs/       # Personal documents (Identity, Health, Finance, Legal,
-│               # Auto, Housing, Travel, Events, Gear, Music, Personality,
-│               # Recovery Codes, Reference)
+│               # Auto, Housing, Travel, Events, Gear, Music,
+│               # Personality, Recovery Codes, Reference)
 ├── share/      # Material shared with specific people
-└── workspace/  # Non-code projects that fit in Google Drive
+└── workspace/  # Non-code projects that fit in the cloud drive
 ```
+
+The `life-atlas` repo contains **documentation and setup scripts about Atlas — not Atlas data itself.** Never commit personal documents, identity docs, keys, or anything from `~/Atlas/docs/` or `~/Atlas/config/keys/` into this repo.
 
 ---
 
 ## What lives outside Atlas (and why)
 
-Not everything belongs in Google Drive. These stay local and are managed by other tools:
+Not everything belongs in a cloud drive. These paths stay on a workstation, managed by other tools:
 
-| Path | Purpose | Why outside Atlas |
+| Path (reference impl.) | Role | Why outside Atlas |
 |---|---|---|
-| `~/workspace/` | Code repositories | Managed by git/GitHub; binary-heavy |
-| `~/Pictures/` | DSLR / drone originals, editing libraries | Too large, too volatile for Drive |
-| Syntheus Google Drive | Consulting work | Separate company Drive, different account |
+| `~/workspace/` | Code repositories | Managed by git; `.git/` and large `node_modules/` degrade cloud sync |
+| `~/Pictures/` | DSLR / drone originals, editing libraries | Too large, too volatile for cloud sync |
+| Syntheus cloud drive | Consulting work | Separate account, separate ownership |
 
 ---
 
 ## The "workspace" pattern
 
-`workspace` is a **role, not a single path.** It means "a folder that holds projects." A workspace can exist in multiple places based on project characteristics:
+`workspace` is a **role, not a single path.** It means "a folder that holds projects." A workspace exists in multiple places:
 
-| Location | Contents | Reason |
-|---|---|---|
-| `~/Atlas/workspace/` | Non-code projects (planning, writing, personal) | Shareable via Drive |
-| `~/workspace/` | Code repos (this repo, kitted, etc.) | Managed by git |
-| Syntheus Drive workspace | Consulting work | Company-owned cloud |
+| Role | Where (reference) | Contents | Reason |
+|---|---|---|---|
+| Cloud drive workspace | `~/Atlas/workspace/` | Non-code projects (planning, writing, personal) | Shareable via cloud |
+| Local code workspace | `~/workspace/` | Code repositories under git | Version-controlled, binary-heavy |
+| Company cloud workspace | Syntheus cloud drive | Consulting work | Separate account |
 
-If the user says "workspace" and context is ambiguous, ask which one.
+When the user says "workspace" and context is ambiguous, ask which one.
 
 ---
 
@@ -62,11 +86,11 @@ If the user says "workspace" and context is ambiguous, ask which one.
 
 ```
 life-atlas/
-├── .claude/                # Skills, settings for Claude Code
+├── .claude/                # Skills, commands, settings for Claude Code
 ├── device-schemas/         # Folder structure per device
 ├── folder-schemas/         # Conceptual schemas per top-level folder
 ├── environment/            # Shell scripts and environment config
-├── bookmarks/              # Browser bookmarks (per context)
+├── bookmarks/              # Bookmark strategy (not bookmark data)
 ├── docs/                   # Plans, session scratch (scratch is gitignored)
 ├── CLAUDE.md               # This file
 └── README.md               # Public-facing overview
@@ -77,17 +101,28 @@ life-atlas/
 ## Conventions
 
 ### Tone
-- **README and schema docs: external.** Write as if for others picking this up. Avoid "I" / "my."
-- **CLAUDE.md: internal.** First-person OK. This file is not part of the public surface.
+- **README, schema docs, bookmarks README: external.** Prefer abstract pattern language. Call out the reference implementation as a specific example, not the only path.
+- **CLAUDE.md: internal.** First-person OK. Can name specific devices and services freely. Not part of the public surface.
+
+### Platform-neutral language (rule)
+
+When docs describe the *pattern*, use abstract terms:
+
+- "cloud drive folder" — not "Google Drive"
+- "primary workstation" / "local workstation" — not "Mac" (in pattern context)
+- "NAS" / "network-attached storage" — not "UGREEN NAS"
+- "mobile device" — not "iPhone"
+
+When docs describe the reference implementation, concrete names are fine. Device-schema docs name specific devices because they describe specific devices.
 
 ### House style for schema docs
 - Emoji section headers (🗂️, 📦, 🔁, etc.)
 - Folder trees inside fenced code blocks
 - Tables for sync strategy / tool mapping
-- Keep short; link back to README for rationale
+- Kept short; link back to README for rationale
 
 ### README is canonical
-If README and a device-schema disagree, **README wins.** Update the schema to match, not the other way.
+If README and a device/folder schema disagree, **README wins.** Update the schema to match, not the other way.
 
 ### Shell scripts must be idempotent
 All scripts in `environment/` must be safe to rerun with the same outcome. Required patterns:
@@ -98,18 +133,21 @@ All scripts in `environment/` must be safe to rerun with the same outcome. Requi
 - `defaults write` is idempotent — safe to use freely
 
 ### Never do
-- Don't edit files inside `~/Atlas/` directly from this repo's scripts. Google Drive owns that path; this repo describes the structure, users create it in their own Drive.
+- Don't edit files inside `~/Atlas/` directly from this repo's scripts. The cloud drive app owns that path; this repo describes the structure.
 - Don't commit content from `~/Atlas/docs/`, `~/Atlas/config/keys/`, or any other personal-data path.
-- Don't assume a `~/Kit/` path exists — the "Kit" model was an earlier design that Atlas superseded.
+- Don't assume a `~/Kit/` path exists — "Kit" was an earlier design that Atlas superseded.
 
 ---
 
 ## Session workflow
 
-This repo uses session-start / session-end skills ported from the `kitted` project.
+This repo uses these skills and commands:
 
-- **`/session-start`** — checks git state, open issues (`gh issue list`), active plans in `docs/plans/`, initializes `docs/session-scratch.md` for observations
+- **`/session-start`** — reviews git state, open issues, active plans in `docs/plans/`, initializes `docs/session-scratch.md`
 - **`/session-end`** — processes scratch into GitHub issues with labels, commits, pushes, cleans up
+- **`/audit`** — scan the repo for drift (empty stubs, broken links, legacy references)
+- **`/sync-check`** — verify on-disk reality matches what the schemas describe
+- **`/plan-new <name> "<title>"`** — scaffold a new plan file in `docs/plans/`
 
 ### Required GitHub labels
 
@@ -117,17 +155,18 @@ Session-end assumes these labels exist on `andrewhml/life-atlas`. Create with `g
 
 - Type: `ready`, `idea`, `bug`, `feature`, `chore`, `docs`
 - Priority: `priority/high`, `priority/medium`, `priority/low`
-- Area: `area/device-schemas`, `area/folder-schemas`, `area/environment`, `area/bookmarks`, `area/docs`, `area/meta`
+- Area: `area/device-schemas`, `area/folder-schemas`, `area/environment`, `area/bookmarks`, `area/docs`, `area/meta`, `area/drift`
 
 ---
 
 ## Known drift (pending cleanup)
 
-The repo is mid-reconciliation. Items to watch for:
+The repo is mid-reconciliation. Items tracked in GitHub issues:
 
-- **`environment/macos_environment_init.sh`** — creates `~/Atlas-Example/` demo dirs from an earlier design; does not match the real Atlas structure.
-- **`~/Atlas/README.md` on disk** — calls itself "Atlas Example / feel free to remove," leftover from the init script. Stale.
-- **Legacy `~/System/` on personal Mac** — pre-Atlas; contents should migrate to `~/Atlas/config/` over time.
-- **Empty stub files** in `device-schemas/`, `folder-schemas/`, `environment/` — pending triage.
+- **`environment/macos_environment_init.sh`** — creates demo dirs from an earlier design. [#1]
+- **`~/Atlas/README.md` on disk** — stale demo text. [#6]
+- **Legacy `~/System/` on personal Mac** — pre-Atlas; migrate into `~/Atlas/config/`. [#5]
+- **Empty environment stubs** — pending real content. [#2]
+- **Obsidian vaults** — pending strategy decision. [#3]
 
-Tracked via open GitHub issues. Check `gh issue list --label area/drift` for status.
+Check `gh issue list --label area/drift` for current status.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🧭 Life Atlas
 
-A personal digital-organization system built around **Atlas** — a Google-Drive-synced folder that holds important documents, cross-device config, and shareable material, backed up to a home NAS.
+A personal digital-organization system built around **Atlas** — a cross-device pattern for keeping important documents, cross-device config, shareable material, and daily working state organized across desktops, laptops, phones, tablets, and network storage.
 
 ---
 
@@ -9,28 +9,50 @@ A personal digital-organization system built around **Atlas** — a Google-Drive
 Atlas helps you:
 
 - Keep important documents (IDs, health, finance, legal) accessible from any device
-- Share cross-device configuration: app settings, shortcuts, templates
-- Maintain a consistent structure across Mac, iPad, iPhone, and NAS
+- Share cross-device configuration: app settings, shortcuts, templates, themes
+- Maintain a consistent mental model for where anything lives — laptop, phone, tablet, NAS
 - Separate cloud-synced material from local-only work (code, large media)
+- Back up everything locally on a NAS in addition to cloud storage
 
 ---
 
-## 💻 Devices covered
+## 🧩 The Atlas pattern
 
-- MacBook Pro (Personal)
-- MacBook Pro (Work)
-- Personal PC (Windows or Linux)
-- UGREEN NAS (Peddocks2)
-- iPad (2024)
-- iPhone 16 Pro
+Atlas is implementation-agnostic. It describes a set of roles:
+
+| Role | Purpose |
+|---|---|
+| **Cloud drive folder** | Source of truth for documents, config, shareable material |
+| **Primary workstation** | Active work; local mirror of the cloud drive |
+| **Secondary workstation** | Additional desktop (different OS or role, e.g., GPU work) |
+| **Company workstation** | Work-issued device; personal Atlas NOT synced here |
+| **Network-attached storage** | Local backup of cloud drive + Time Machine + media library |
+| **Mobile devices** | Phones and tablets with read-often access to the cloud drive |
+
+Pick a tool for each role and stay consistent. The schemas and scripts in this repo describe conventions that apply across implementations.
+
+---
+
+## 🔧 Reference implementation
+
+This repo is currently developed against one concrete setup. Adapt as needed:
+
+| Role | Reference choice |
+|---|---|
+| Cloud drive folder | Google Drive (`~/Atlas/`) |
+| Primary workstation | MacBook Pro (macOS, personal) |
+| Secondary workstation | Windows 11 Pro PC |
+| Company workstation | MacBook Pro (macOS, work) |
+| NAS | UGREEN (`Peddocks2` at `/Volumes/personal_folder/Atlas`) |
+| Phone | iPhone 16 Pro |
+| Tablet | iPad 2024 |
+| Consulting cloud | Separate Syntheus Google Drive |
 
 See `device-schemas/` for per-device folder layout and setup.
 
 ---
 
-## 🗂️ Atlas structure
-
-Atlas lives at `~/Atlas/` on macOS and mirrors to `/Volumes/personal_folder/Atlas` on the `Peddocks2` NAS.
+## 🗂️ Cloud drive folder structure
 
 ```
 ~/Atlas/
@@ -59,41 +81,44 @@ Atlas lives at `~/Atlas/` on macOS and mirrors to `/Volumes/personal_folder/Atla
 │   ├── Reference/
 │   └── Travel/
 ├── share/      # Material shared with specific people
-└── workspace/  # Non-code projects that fit in Google Drive
+└── workspace/  # Non-code projects that fit in the cloud drive
 ```
 
 ---
 
 ## 🏠 What lives outside Atlas
 
-Not everything belongs in Google Drive. Some paths stay local on the Mac, managed by other tools:
+Not everything belongs in a cloud drive. These stay local, managed by other tools:
 
-| Path | Purpose | Why not in Atlas |
+| Path | Role | Why not in Atlas |
 |---|---|---|
-| `~/workspace/` | Code repositories | Managed by git / GitHub |
-| `~/Pictures/` | DSLR / drone originals, editing libraries | Too large, too volatile |
-| Syntheus Google Drive | Consulting work | Separate company account |
+| Local code workspace | Code repositories | Managed by git; `.git/` and large `node_modules/` trees degrade cloud sync |
+| Local media folder | DSLR / drone originals, editing libraries | Too large, too volatile |
+| Separate company cloud | Consulting / employer work | Different account, different ownership |
 
-The pattern: **Atlas for anything shareable, searchable, and cloud-friendly. Local for anything that is tool-managed, binary-heavy, or workflow-specific.**
+The pattern: **Atlas for anything shareable, searchable, and cloud-friendly. Local for anything tool-managed, binary-heavy, or workflow-specific.**
 
 ---
 
 ## 🔁 Sync topology
 
 ```
-┌──────────────────┐       ┌──────────────────┐       ┌──────────────────┐
-│  Google Drive    │ <===> │  Mac ~/Atlas/    │ <===> │  NAS Peddocks2   │
-│  (cloud master)  │       │  (local working) │       │  /Volumes/       │
-│                  │       │                  │       │  personal_folder │
-└──────────────────┘       └──────────────────┘       │  /Atlas          │
-                                                       └──────────────────┘
+┌──────────────────┐       ┌────────────────────┐       ┌──────────────────┐
+│  Cloud drive     │ <===> │  Workstation       │ <===> │  NAS             │
+│  (source of      │       │  local Atlas dir   │       │  local mirror +  │
+│   truth)         │       │                    │       │  media library   │
+└──────────────────┘       └────────────────────┘       └──────────────────┘
+        ↑                          ↕                              ↑
+        └──── Mobile apps          Time Machine ──────────────────┘
+                                    (system backup)
 ```
 
-| Link | Method | Direction |
+| Link | Reference method | Direction |
 |---|---|---|
-| Cloud ↔ Mac | Google Drive desktop app | Bidirectional |
-| Mac ↔ NAS | UGREEN Cloud Drive (Google Drive integration) | Bidirectional |
-| Mac → NAS | Time Machine | System backup |
+| Cloud ↔ Primary workstation | Cloud drive desktop app (Google Drive for Desktop) | Bidirectional |
+| Primary workstation ↔ NAS | NAS cloud-drive integration (UGREEN Cloud Drive) | Bidirectional |
+| Primary workstation → NAS | Time Machine | System backup |
+| Cloud ↔ Mobile | Cloud drive native app | Bidirectional |
 
 ---
 
@@ -109,8 +134,8 @@ life-atlas/
 │   ├── ipad.md
 │   └── iphone.md
 ├── folder-schemas/       # Conceptual schemas per top-level folder
-├── environment/          # macOS setup scripts, Brewfile docs
-├── bookmarks/            # Browser bookmarks by context
+├── environment/          # Setup scripts, Brewfile docs
+├── bookmarks/            # Bookmark strategy
 ├── CLAUDE.md             # Project guide for Claude Code
 └── README.md             # This file
 ```
@@ -119,17 +144,18 @@ life-atlas/
 
 ## 🚀 Getting started
 
-1. **Install Google Drive desktop app** on your Mac. Sign in with the account that hosts your Atlas folder.
-2. **Create `~/Atlas/`** in Google Drive (or mirror the structure above in your existing Drive root).
-3. **Configure NAS sync** via UGREEN Cloud Drive → Google Drive, pointed at `/Volumes/personal_folder/Atlas` (or equivalent NAS share).
-4. **Clone this repo** into `~/workspace/personal/life-atlas` for access to scripts and schema docs.
-5. **Run setup scripts** from `environment/` as needed (see per-device schema for specifics).
+1. **Pick a cloud drive** (Google Drive, iCloud Drive, OneDrive, Dropbox) and install its desktop client on your primary workstation.
+2. **Create an Atlas root folder** in the cloud drive using the structure above, or adapt the names to your preference.
+3. **Configure NAS mirror** if you have a NAS — most modern NASes (Synology, UGREEN, QNAP) support cloud-drive sync.
+4. **Install cloud drive app** on phones and tablets; enable selective offline sync for key folders.
+5. **Clone this repo** to your local code workspace for access to scripts and schema docs.
+6. **Run setup scripts** from `environment/` for your platform (see per-device schemas).
 
 ---
 
 ## 📝 Notes
 
-- Atlas is the cloud-synced portion. Local-only paths exist for things Google Drive is poorly suited to hold.
-- The NAS (`Peddocks2`) is a **backup mirror**, not a primary source of truth. Google Drive is the master.
-- This repo holds documentation and setup scripts. It does not contain Atlas data.
-- Structures shown here are recommendations. Adapt folder names and nesting to your workflow.
+- This repo holds **documentation and setup scripts** about Atlas. It does not contain Atlas data.
+- Names and paths shown here are from the reference implementation. Adapt to your tools, accounts, and workflows.
+- The cloud drive is the **source of truth**. The NAS is a **mirror**. Mobile devices are **consumers**.
+- Atlas is intentionally comprehensive: it covers documents, config, shared material, and mobile access — not just a document archive.

--- a/bookmarks/README.md
+++ b/bookmarks/README.md
@@ -1,14 +1,14 @@
 # 🔖 Bookmarks
 
-Strategy and schema for browser bookmarks across devices.
+Strategy for browser bookmarks across devices.
 
 ---
 
-## 🎯 Current Approach
+## 🎯 Approach
 
-**Live sync:** Brave Sync keeps bookmarks current across Brave installations (Mac, PC, mobile).
+**Live sync:** Browser-native sync (e.g., Brave Sync, Chrome Sync, Firefox Sync) keeps bookmarks current across installations on desktop and mobile.
 
-**Snapshots:** Periodic HTML exports go to `~/Atlas/config/bookmarks_<MM_DD_YY>.html` for:
+**Snapshots:** Periodic HTML exports go to the cloud drive at `config/bookmarks_<MM_DD_YY>.html` for:
 
 - Portability if switching browsers
 - Rollback if sync goes wrong
@@ -24,21 +24,30 @@ Bookmarks in the browser should be organized by context. Recommended top-level f
 Bookmarks Bar/
 ├── Personal/          # Personal reading, tools, accounts
 ├── Work/              # Employer-related
-├── Syntheus/          # Consulting work
+├── Consulting/        # Client / consulting work (if applicable)
 └── Reading List/      # Queued articles, long-form
 ```
 
-Nested folders within each context are fine; keep the top-level consistent.
+Nested folders within each context are fine; keep the top-level consistent across browsers and devices.
 
 ---
 
 ## 🔁 Export Workflow
 
-When bookmarks reach a meaningful state (big cleanup, before switching browsers, quarterly):
+When bookmarks reach a meaningful state (after a big cleanup, before switching browsers, quarterly):
 
 1. Export from the browser as HTML: `bookmarks_MM_DD_YY.html`
-2. Save to `~/Atlas/config/` (auto-syncs to Drive + NAS)
+2. Save to the cloud drive `config/` folder
 3. Remove the previous export, or keep it for rollback
+
+---
+
+## 🔧 Reference implementation
+
+- Primary browser: Brave (desktop + mobile)
+- Live sync: Brave Sync
+- Snapshot location: `~/Atlas/config/bookmarks_<MM_DD_YY>.html`
+- Most recent snapshot: `bookmarks_4_21_26.html`
 
 ---
 
@@ -46,12 +55,12 @@ When bookmarks reach a meaningful state (big cleanup, before switching browsers,
 
 - Single HTML export vs per-context JSON — which is easier to port between browsers?
 - Is there value in also maintaining a parsed / structured copy (e.g., Markdown list) alongside the HTML?
-- Cross-browser import fidelity (Brave → Firefox → Safari) — test before committing to a single path.
+- Cross-browser import fidelity — test before committing to a single path.
 
 ---
 
 ## 📝 Notes
 
-- This repo does **not** hold bookmark data. Actual exports live in `~/Atlas/config/` (Drive-synced).
-- Mobile browsers sync via browser-native mechanisms; Brave Sync extends to mobile when signed in.
-- "Bookmarks well organized and easily ported" is a project completion criterion — track progress via `area/bookmarks` GitHub issues.
+- This repo does **not** hold bookmark data. Actual exports live in the cloud drive `config/`.
+- Mobile browsers sync via the browser's native mechanism; each major browser has its own solution.
+- "Bookmarks well organized and easily ported" is a project completion criterion — track via `area/bookmarks` GitHub issues.

--- a/docs/plans/0001-macos-environment-init-rewrite.md
+++ b/docs/plans/0001-macos-environment-init-rewrite.md
@@ -1,0 +1,104 @@
+# Plan 0001 — Rewrite macos_environment_init.sh for the Atlas model
+
+**Status:** Draft
+**Issue:** #1
+**Created:** 2026-04-21
+
+---
+
+## Goal
+
+Replace the existing `environment/macos_environment_init.sh` (which creates `~/Atlas-Example/`, `~/Workspace-Example/`, `~/Media-Example/`, `~/System-Example/` demo directories from an earlier design) with a bootstrap script that correctly sets up a new macOS primary workstation under the real Atlas model.
+
+The script should be safe to run on a machine that already has partial Atlas setup, idempotent across reruns, and opinionated about what it will and won't touch.
+
+## Scope
+
+- **In:**
+  - Verify Google Drive for Desktop is installed
+  - Verify `~/Atlas/` exists and is being synced (fail loudly if not — don't create it, since the Drive app owns that path)
+  - Create local-only outside-Atlas paths: `~/workspace/`, `~/Pictures/` with year-folder scaffolding on request
+  - Prompt for NAS mount (`/Volumes/personal_folder/Atlas`) and provide SMB mount helper
+  - Install core CLI tooling via Homebrew (via existing Brewfile or inline bootstrap)
+  - Configure git global identity if not already set
+  - Clean up any leftover `~/*-Example/` directories from previous runs (prompt before deletion)
+- **Out:**
+  - Creating or mutating anything inside `~/Atlas/` (Drive's territory)
+  - Installing every app in the user's ecosystem (that's `devtools.sh` + Brewfile territory)
+  - Configuring macOS defaults (that's `defaults_settings.sh`)
+  - Setting up the NAS itself (that's `nas-setup.md`)
+
+## Approach
+
+### Phase 1 — Pre-flight checks
+
+**Goal:** Fail fast if the environment isn't ready.
+
+**Steps:**
+1. Check macOS version (>= 14)
+2. Check Google Drive for Desktop is installed (`/Applications/Google Drive.app`)
+3. Check `~/Atlas/` exists and is non-empty
+4. Check user confirms this is the primary personal Mac (not a work Mac)
+
+**Exit criteria:** All checks pass or the script exits with a clear message.
+
+### Phase 2 — Local directory scaffolding
+
+**Goal:** Create local-only paths the Atlas model relies on.
+
+**Steps:**
+1. `mkdir -p ~/workspace/{personal,work}`
+2. `mkdir -p ~/Pictures`
+3. Optionally invoke `macos_create_photo_year.sh $(date +%Y)` to scaffold the current year
+
+**Exit criteria:** Paths exist and are writable.
+
+### Phase 3 — Legacy cleanup
+
+**Goal:** Remove leftover example directories from prior runs of this script or the old Kit-based design.
+
+**Steps:**
+1. Detect `~/Atlas-Example/`, `~/Workspace-Example/`, `~/Media-Example/`, `~/System-Example/`, `~/Atlas-Example-Aliases.txt`, `~/Kit/`
+2. Prompt user with list of detected legacy items
+3. On confirmation, delete
+
+**Exit criteria:** No legacy directories remain.
+
+### Phase 4 — Tooling
+
+**Goal:** Core CLI toolchain is present.
+
+**Steps:**
+1. Check Homebrew is installed; install if missing
+2. Run `brew bundle --file=<path>` if a Brewfile exists in the repo (reference `brewfile.md`)
+3. Check `gh`, `git`, `zsh` are on PATH
+4. Prompt for git global identity if not set
+
+**Exit criteria:** Required commands work.
+
+### Phase 5 — NAS mount helper (optional)
+
+**Goal:** Make it easy to mount the NAS Atlas mirror when on the home network.
+
+**Steps:**
+1. Provide an `alias mount-atlas-nas='mount_smbfs ...'` snippet for `shell-aliases.sh`
+2. Optionally create a LaunchAgent to auto-mount on login (prompt first)
+
+**Exit criteria:** Mount works from the alias.
+
+## Risks
+
+- **Google Drive not installed or signed in:** script can't create `~/Atlas/`; user has to do this manually. Script must not attempt to create it. Pre-flight catches this.
+- **Running on work Mac:** could sync personal Atlas to a company device. Pre-flight asks the user to confirm primary personal Mac.
+- **Destructive cleanup:** user might have put real work in `~/*-Example/` since the init script ran. Prompt before every delete; show contents count.
+- **Homebrew install hangs:** first install prompts for sudo and can stall. Document expectations up front.
+
+## Open questions
+
+- Should the NAS mount helper live in this script, or in `nas-setup.md` / a separate `mount-nas.sh`? Favor separation (this script is about the Mac, not the NAS).
+- Should the script write a marker file (`~/.life-atlas-initialized`) so reruns are no-ops? Probably yes, but make it optional via `--force`.
+- Should the script be interactive-only, or also support non-interactive CI-style runs? Probably interactive for now; revisit if onboarding a new Mac becomes routine.
+
+## Status log
+
+- 2026-04-21 — Plan drafted as part of Phase 3 refinement (issue #1)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,27 @@
+# Plans
+
+Multi-step implementation plans live here. Each plan is a single markdown file.
+
+---
+
+## Convention
+
+- **Filename:** `NNNN-<short-name>.md` — four-digit zero-padded number, kebab-case name
+- **Status markers** in header: `Draft`, `In Progress`, `Complete`, `Abandoned`
+- **Active plans** are surfaced at session-start; look for `In Progress` in the header
+- **Completed plans** stay here for reference; when the list grows long, move to `archive/`
+
+## Scaffolding
+
+Use `/plan-new <short-name> "<title>"` to create a new plan from the template.
+
+## Relationship to GitHub issues
+
+- **GitHub issues** = units of work (`ready`, `idea`, `bug`, etc.)
+- **Plans** = how we're approaching a bigger piece of work that spans multiple issues or touches multiple areas
+
+A plan may reference one or more GitHub issues in its header. A small self-contained issue doesn't need a plan — do it directly.
+
+## Archive
+
+When plans complete and the list gets noisy, move them into `archive/YYYY/` to preserve history while keeping the active list scannable.

--- a/folder-schemas/media.md
+++ b/folder-schemas/media.md
@@ -1,25 +1,25 @@
 # 🖼️ Media — Folder Schema
 
-Media is **local-first, NAS-archived.** It does not sync to Atlas because:
+Media is **local-first, NAS-archived.** It does not sync to the cloud drive because:
 
-- DSLR / drone originals are too large for Drive quotas
-- Lightroom / Photoshop libraries are volatile and tool-managed
-- Re-upload on sync conflict can be destructive to catalog state
+- Camera / drone originals are too large for typical cloud-drive quotas
+- Editing libraries (Lightroom catalogs, Photoshop files) are volatile and tool-managed
+- Cloud sync on catalog state can be destructive
 
 ---
 
-## 📍 Locations
+## 📍 Roles
 
-| Location | Contents | Purpose |
+| Role | Where it lives (reference) | Purpose |
 |---|---|---|
-| `~/Pictures/` on Mac | Working originals, editing libraries | Active photo / video work |
-| NAS `Media/photos/` | Archived yearly content | Long-term storage; Plex / Immich serving |
-| NAS `Media/{movies, music, tvshows, books}/` | Family media libraries | Plex serving |
-| iPhone Camera Roll / iCloud Photos | iPhone captures | Separate flow; not part of DSLR pipeline |
+| Working media folder | `~/Pictures/` on the primary workstation | Active photo / video work |
+| Archive on NAS | NAS `Media/photos/` | Long-term storage; Plex / Immich serving |
+| Family media library | NAS `Media/{movies, music, tvshows, books}/` | Plex serving |
+| Phone captures | Phone-native cloud (iCloud Photos / Google Photos) | Separate flow; not part of the camera pipeline |
 
 ---
 
-## 📂 Mac `~/Pictures/` Structure
+## 📂 Working Media Folder Structure
 
 ```
 Pictures/
@@ -29,7 +29,7 @@ Pictures/
 │   ├── Processed/                  # Lightroom / export output
 │   └── Video/
 ├── Lightroom-Library/              # Lightroom catalog + previews
-└── Photos Library.photoslibrary    # Apple Photos (macOS default)
+└── Photos Library.photoslibrary    # OS-native photo library (if used)
 ```
 
 Scaffold a new year with `environment/macos_create_photo_year.sh YYYY`.
@@ -38,11 +38,11 @@ Scaffold a new year with `environment/macos_create_photo_year.sh YYYY`.
 
 ## 🔁 Lifecycle
 
-1. **Import** — DSLR / drone card → `~/Pictures/YYYY-Photos/RAW/YYYY-MM/`
-2. **Edit** — Lightroom / Photoshop; catalog stays in `~/Pictures/Lightroom-Library/`
-3. **Export** — Processed output to `~/Pictures/YYYY-Photos/Processed/`
+1. **Import** — camera / drone card → `Pictures/YYYY-Photos/RAW/YYYY-MM/`
+2. **Edit** — Lightroom / Photoshop; catalog stays in `Pictures/Lightroom-Library/`
+3. **Export** — Processed output to `Pictures/YYYY-Photos/Processed/`
 4. **Review period** — Material stays local while the year is active
-5. **Archive** — When the year is complete, rsync `YYYY-Photos/` to NAS `Media/photos/`; optionally thin from Mac after verification
+5. **Archive** — When the year is complete, rsync `YYYY-Photos/` to NAS `Media/photos/`; optionally thin from workstation after verification
 
 ---
 
@@ -54,6 +54,6 @@ See [`device-schemas/nas-structure.md`](../device-schemas/nas-structure.md) for 
 
 ## 📝 Notes
 
-- iPhone photos do not flow through this pipeline. They live in iCloud Photos.
-- Videos from iPhone needing editing should be exported to `~/Pictures/YYYY-Photos/Video/` manually.
+- Phone photos do not flow through this pipeline. They live in the phone's native cloud service.
+- Phone videos that need editing should be exported to the workstation's `Pictures/YYYY-Photos/Video/` manually.
 - Do not mount NAS `Media/photos/` as a primary Lightroom catalog location — network latency harms editing.

--- a/folder-schemas/workspace.md
+++ b/folder-schemas/workspace.md
@@ -4,13 +4,15 @@
 
 ---
 
-## 📍 Locations
+## 📍 Roles
 
-| Location | Contents | Reason for separation |
-|---|---|---|
-| `~/Atlas/workspace/` | Non-code projects (planning, writing, personal) | Fits Google Drive; shareable |
-| `~/workspace/` | Code repositories managed by git | Too large / binary-heavy for Drive |
-| Syntheus Google Drive | Consulting work | Separate company account |
+| Role | Where it lives (reference) | Contents | Why separate |
+|---|---|---|---|
+| Cloud drive workspace | `~/Atlas/workspace/` | Non-code projects (planning, writing, personal) | Fits cloud drive; shareable |
+| Local code workspace | `~/workspace/` | Code repositories under version control | Binary-heavy for cloud sync |
+| Company cloud workspace | Syntheus cloud drive | Consulting work | Separate company account |
+
+Pick the right workspace for each project based on **what it is made of**, not where you happen to be when you start it.
 
 ---
 
@@ -27,7 +29,7 @@ workspace/
 The Syntheus workspace uses project-lifecycle buckets:
 
 ```
-workspace/ (Syntheus Drive)
+workspace/ (Syntheus cloud drive)
 ├── active-projects/
 ├── proposals/
 ├── resources/
@@ -43,25 +45,25 @@ Client work sits in subfolders under `active-projects/`.
 
 Ask in order:
 
-1. **Is it code under version control?** → `~/workspace/`
-2. **Is it for Syntheus / a consulting engagement?** → Syntheus Drive workspace
-3. **Is it a personal project that's documents / planning / writing?** → `~/Atlas/workspace/personal/`
-4. **Is it work-adjacent but not code?** → `~/Atlas/workspace/work/`
+1. **Is it code under version control?** → local code workspace
+2. **Is it for a consulting engagement?** → company cloud workspace
+3. **Is it a personal project that's documents / planning / writing?** → cloud drive workspace (`personal/`)
+4. **Is it work-adjacent but not code?** → cloud drive workspace (`work/`)
 
-When unclear, prefer `~/Atlas/workspace/` — the cloud-synced default.
+When unclear, prefer the cloud drive workspace — the shareable, portable default.
 
 ---
 
 ## 🚫 Anti-patterns
 
-- Do not put code repositories inside `~/Atlas/workspace/`. Google Drive does not handle `.git/` well, and large `node_modules/` trees cause sync thrash.
+- Do not put code repositories inside the cloud drive workspace. Cloud drives handle `.git/` poorly; large `node_modules/` trees cause sync thrash.
 - Do not duplicate a project across workspaces. Pick one; link or reference from the other.
-- Do not mix personal and Syntheus work in one workspace root.
+- Do not mix personal and consulting work in one workspace root.
 
 ---
 
 ## 📝 Notes
 
 - "Project" is whatever the owner treats as a project. A single-file script and a multi-month engagement both qualify.
-- Archived projects move to `~/Atlas/archive/` (for Atlas workspaces) or a dated subfolder (for the code workspace).
-- When context is ambiguous in conversation (user says "my workspace"), ask which workspace is meant.
+- Archived projects move to `archive/` in the cloud drive, or to a dated subfolder in the code workspace.
+- When context is ambiguous in conversation ("my workspace"), ask which workspace is meant.


### PR DESCRIPTION
## Summary

Makes the life-atlas docs platform-neutral, widens the Atlas scope to include PC and mobile devices, and adds custom slash commands plus a plans convention.

Builds on #7.

## Changes

**Platform-neutral rewrite (4fc5fa8)**
- Docs now describe the pattern abstractly (\"cloud drive folder,\" \"primary workstation,\" \"NAS,\" \"mobile device\") with the user's Google Drive / Mac / UGREEN / iPhone setup called out as a reference implementation
- `CLAUDE.md` now includes the Windows 11 Pro PC (NVIDIA RTX 5080), iPhone, and iPad in the Atlas device scope
- \"What Atlas is\" broadened to reflect the comprehensive manifesto across desktop, mobile, PC, and NAS
- `bookmarks/README.md` is browser-agnostic with Brave as the reference

**Claude Code tooling (80d33a6)**
- `/audit` — scan repo for drift (empty stubs, broken links, legacy references, cruft)
- `/sync-check` — verify on-disk reality matches the schemas (no user data reads)
- `/plan-new <name> \"<title>\"` — scaffold a plan file from template
- `docs/plans/` convention established; first plan (0001) tied to issue #1

## Test plan

- [ ] Run `/audit` to validate it works against the current tree
- [ ] Run `/sync-check` to validate filesystem checks
- [ ] Confirm abstract language reads naturally in README and CLAUDE.md