### PR TITLE
Apply Claude Code best-practice audit + description refinements

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,10 +1,18 @@
 ---
-description: Scan the life-atlas repo for drift, empty stubs, broken cross-references, and legacy references
+description: Find repo drift — empty stubs, broken links, legacy term references, OS cruft
 ---
 
 # /audit
 
 Scan the life-atlas repo for drift.
+
+## Usage
+
+```
+/audit
+```
+
+No arguments. Scans the whole repo.
 
 ## What to check
 

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,5 +1,5 @@
 ---
-description: Find repo drift — empty stubs, broken links, legacy term references, OS cruft
+description: Scan the life-atlas repo for drift. Use when the user wants to verify docs are consistent, asks "does this still line up," or before a big commit. Finds empty stubs, broken markdown cross-references, legacy term references (Kit/, LiveDocs/, Vault/), and OS cruft.
 ---
 
 # /audit

--- a/.claude/commands/plan-new.md
+++ b/.claude/commands/plan-new.md
@@ -1,5 +1,5 @@
 ---
-description: Scaffold a new plan file in docs/plans/ using the life-atlas plan template
+description: Create a new multi-phase plan file in docs/plans/. Use when the user says "write a plan," "let's plan this out," "draft an approach," or starts multi-phase work that needs structured tracking. Generates sequentially numbered plan file from the template (goal, phases, risks, open questions).
 ---
 
 # /plan-new

--- a/.claude/commands/sync-check.md
+++ b/.claude/commands/sync-check.md
@@ -1,10 +1,18 @@
 ---
-description: Verify the on-disk filesystem on this workstation matches what life-atlas schemas describe
+description: Verify filesystem matches documented schemas — check cloud drive, NAS mount, legacy paths
 ---
 
 # /sync-check
 
 Verify the on-disk reality matches what life-atlas documents.
+
+## Usage
+
+```
+/sync-check
+```
+
+No arguments. Runs against the current workstation.
 
 Life-atlas describes *target* structure. Actual filesystem state can drift. This command checks, without touching user data.
 
@@ -20,7 +28,7 @@ Life-atlas describes *target* structure. Actual filesystem state can drift. This
 
 5. **Legacy paths** — does `~/System/`, `~/Kit/`, or any `~/*-Example/` directory exist? These are legacy / leftover and flagged for cleanup.
 
-6. **Repo's own expected paths** — is `docs/` present (session scratch location)? Is `.claude/skills/` populated?
+6. **Repo's own expected paths** — `docs/` exists (session-scratch location); `.claude/skills/` contains at least one `SKILL.md`; `.claude/commands/` contains at least one command file.
 
 ## How to run
 

--- a/.claude/commands/sync-check.md
+++ b/.claude/commands/sync-check.md
@@ -1,5 +1,5 @@
 ---
-description: Verify filesystem matches documented schemas — check cloud drive, NAS mount, legacy paths
+description: Verify the current workstation's filesystem matches life-atlas schemas. Use when setting up a new device, after reconfiguring a sync tool, or when the user asks "is everything in the right place." Checks cloud drive subfolders, local workspace and pictures paths, NAS mount, and flags legacy paths.
 ---
 
 # /sync-check

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Process session observations into GitHub issues, stage and commit changes, push branch
+description: Wrap up a life-atlas work session. Process docs/session-scratch.md into labeled GitHub issues, stage and commit, push the branch. Use when the user signals they're done, wrapping up, or stepping away — not only when they explicitly say "session end".
 ---
 
 # Session End

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: End session — process observations into issues, commit, push
+description: Process session observations into GitHub issues, stage and commit changes, push branch
 ---
 
 # Session End
@@ -67,11 +67,14 @@ EOF
 gh issue create --title "[title]" --label "idea,[area]" --body "[1-3 sentence description]"
 ```
 
-## 4. Update MEMORY.md
+## 4. Capture learnings (if any)
 
-If something was learned during the session that future sessions need (a gotcha, a pattern, a quirk):
-- Append to MEMORY.md Session Learnings section
-- Keep it to one-liners. If it's a pattern, add it to CLAUDE.md or a skill instead.
+If something was learned during the session that future sessions need — a gotcha, a pattern, a quirk — route it:
+- Pattern or durable rule → add to `CLAUDE.md` conventions or a skill
+- One-off gotcha that future Claude sessions should recall → flag to the user; it will be saved to Claude's memory outside the repo
+- Nothing to capture → skip this step
+
+This repo has no `MEMORY.md`. Do not create one; cross-session state lives in Claude's memory system.
 
 ## 5. Handle uncommitted work
 

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Start a new session — load context, check project status, orient
+description: Load project context: check git state, open issues, active plans; initialize session scratch
 ---
 
 # Session Start

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Load project context: check git state, open issues, active plans; initialize session scratch
+description: Orient at the start of a life-atlas session. Check git state, list open GitHub issues, surface active plans in docs/plans/, initialize docs/session-scratch.md. Use when the user is beginning or resuming work on the repo, even without saying "session start" explicitly.
 ---
 
 # Session Start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,11 +143,15 @@ All scripts in `environment/` must be safe to rerun with the same outcome. Requi
 
 This repo uses these skills and commands:
 
-- **`/session-start`** — reviews git state, open issues, active plans in `docs/plans/`, initializes `docs/session-scratch.md`
-- **`/session-end`** — processes scratch into GitHub issues with labels, commits, pushes, cleans up
-- **`/audit`** — scan the repo for drift (empty stubs, broken links, legacy references)
-- **`/sync-check`** — verify on-disk reality matches what the schemas describe
-- **`/plan-new <name> "<title>"`** — scaffold a new plan file in `docs/plans/`
+| Invocation | What it does |
+|---|---|
+| `/session-start` | Review git state, open issues, active plans in `docs/plans/`; initialize `docs/session-scratch.md` |
+| `/session-end` | Process scratch into GitHub issues; stage, commit, push |
+| `/audit` | Scan the repo for drift (empty stubs, broken links, legacy references, cruft) |
+| `/sync-check` | Verify on-disk reality on this workstation matches the schemas |
+| `/plan-new <name> "<title>"` | Scaffold a new plan file in `docs/plans/` |
+
+Skills live in `.claude/skills/`; commands live in `.claude/commands/`.
 
 ### Required GitHub labels
 
@@ -156,6 +160,20 @@ Session-end assumes these labels exist on `andrewhml/life-atlas`. Create with `g
 - Type: `ready`, `idea`, `bug`, `feature`, `chore`, `docs`
 - Priority: `priority/high`, `priority/medium`, `priority/low`
 - Area: `area/device-schemas`, `area/folder-schemas`, `area/environment`, `area/bookmarks`, `area/docs`, `area/meta`, `area/drift`
+
+---
+
+## Permissions & constraints
+
+Claude Code's permissions for this repo are configured in `.claude/settings.json`. The allowlist is intentionally narrow:
+
+- **Write access:** only `.claude/*` and `docs/*`
+- **Bash allowed:** read-only git (`status`, `log`, `branch`, `diff`, `stash`, `show`), plus `gh issue`/`gh label` for session workflow
+- **No write access** to any other repo path without explicit user approval
+- **No access** to files inside `~/Atlas/` (personal data lives there; handled by the cloud drive app)
+- **No access** to `~/Atlas/config/keys/` under any circumstances
+
+If a task requires broader permissions, ask the user first. Don't silently expand the allowlist.
 
 ---
 


### PR DESCRIPTION
## Summary

Two passes of refinement on the Claude Code scaffolding, both driven by assessment:

1. **claude-code-guide agent audit** — structural alignment with Anthropic's published CLAUDE.md and skills best practices
2. **skill-creator description heuristics** — trigger-accuracy pass against the skill-creator's stated principles for description frontmatter

## Changes

**From the structural audit (3f5824e):**
- Strengthen description frontmatter on skills and commands for trigger matching
- Add Usage sections to \`audit.md\` and \`sync-check.md\`
- Clarify \`sync-check\` Step 6 repo-infra check with explicit success criteria
- Replace \`session-end\` Step 4 (stale \`MEMORY.md\` reference from the kitted port) with guidance that routes learnings to CLAUDE.md, skills, or Claude's memory system
- Replace CLAUDE.md's prose list of slash commands with a quick-reference invocation table
- Add an explicit \"Permissions & constraints\" section to CLAUDE.md summarizing what \`.claude/settings.json\` grants and what's off-limits

**From the description pass (49eae55):**
- Each skill/command description now includes explicit trigger contexts (including implicit phrasings) plus concrete surface details
- Descriptions are now ~40-60 words each (up from ~10-15), following skill-creator's guidance that \"pushy\" descriptions combat undertriggering

## Test plan

- [ ] Run \`/audit\` to see if the refreshed description and Usage section feel natural
- [ ] Run \`/sync-check\` to validate Step 6 clarification makes the output scannable
- [ ] Next session, observe whether session-start / session-end trigger more reliably on implicit cues (\"I'm done for now,\" \"just starting up\")