### PR TITLE
Expand permission allowlist from fewer-permission-prompts scan

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,12 @@
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
       "Bash(gh issue create:*)",
-      "Bash(gh label list:*)"
+      "Bash(gh label list:*)",
+      "Bash(npm run typecheck)",
+      "mcp__figma-dev-mode__get_screenshot",
+      "mcp__figma-dev-mode__get_metadata",
+      "mcp__figma-dev-mode__get_variable_defs",
+      "mcp__planpong__planpong_get_feedback"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Applied the \`fewer-permission-prompts\` skill. Scanned 50 most-recent Claude Code transcripts across all projects, filtered to read-only commands not already auto-allowed, added top 5 to this project's \`.claude/settings.json\`.

## Additions

| Pattern | Count | Notes |
|---|---|---|
| \`mcp__figma-dev-mode__get_screenshot\` | 13 | Figma read |
| \`Bash(npm run typecheck)\` | 9 | Read-only type check (exact, not wildcard) |
| \`mcp__planpong__planpong_get_feedback\` | 8 | Planpong read |
| \`mcp__figma-dev-mode__get_metadata\` | 4 | Figma read |
| \`mcp__figma-dev-mode__get_variable_defs\` | 3 | Figma read |

## Honest caveats

- **Cross-project patterns, not life-atlas-specific.** life-atlas primarily uses git + gh + shell, all of which are either auto-allowed by Claude Code or already in the allowlist. The additions benefit this repo only if it ever uses npm / figma / planpong from here. Could alternatively move these to \`~/.claude/settings.json\` (user-global) — but per skill instructions, project-level only.
- **Existing entries are kept as-is** even where redundant with Claude Code's built-in auto-allow (e.g., \`Bash(git status:*)\`, \`Bash(gh issue list:*)\`). The skill rule is \"don't remove anything.\"

## Deliberately NOT added

- \`gh pr merge\` (6), \`gh pr create\` (5) — skill rules exclude merges / creates / writes
- \`npm test\` (8) — tests can have side effects; \"when in doubt, leave it out\"
- \`curl\` (77, all GET today) — no way to constrain wildcard to GET-only; could cover POST
- \`npx\` (37), \`python3 *\` (various), \`npm run *\` wildcard — would grant arbitrary code execution
- All git/shell read-only commands not already in the list — already auto-allowed by Claude Code

## Test plan

- [ ] Next session, observe whether Figma or Planpong calls still prompt
- [ ] Optionally review whether any auto-allowed redundant entries should be cleaned up manually