### PR TITLE
feat: immich-dedup tool + Plan 0002 Phase 2 execution + Plan 0003 close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ The pattern is implementation-agnostic. This user's concrete choices:
 | Secondary workstation | Personal PC (Windows 11 Pro, NVIDIA RTX 5080) |
 | Company workstation | MacBook Pro (work, macOS) |
 | Network-attached storage | UGREEN NAS named `Peddocks2` at `/Volumes/personal_folder/Atlas` |
+| External photo SSDs | SanDisk 2TB × 2: `Carbonizer` (primary, usually mounted) + `Noisy Cricket` (1:1 CCC clone) |
 | Phone | iPhone 16 Pro (Google Drive iOS app) |
 | Tablet | iPad 2024 (Google Drive iOS app) |
 | Consulting cloud | Separate Syntheus Google Drive |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This repo is currently developed against one concrete setup. Adapt as needed:
 | Secondary workstation | Windows 11 Pro PC |
 | Company workstation | MacBook Pro (macOS, work) |
 | NAS | UGREEN (`Peddocks2` at `/Volumes/personal_folder/Atlas`) |
+| External photo SSDs | SanDisk 2TB × 2 (`Carbonizer` + 1:1 clone `Noisy Cricket`) |
 | Phone | iPhone 16 Pro |
 | Tablet | iPad 2024 |
 | Consulting cloud | Separate Syntheus Google Drive |

--- a/device-schemas/external-ssds.md
+++ b/device-schemas/external-ssds.md
@@ -1,0 +1,77 @@
+# 💾 External Photo SSDs — Device Schema
+
+Folder layout and role of the external photo-backup SSDs in the `life-atlas` system.
+
+See the main [README](../README.md) for Atlas structure and sync topology.
+
+---
+
+## 🧾 Hardware
+
+| Drive | Model | Capacity | Filesystem | Connection |
+|---|---|---|---|---|
+| **Carbonizer** | SanDisk 2TB external SSD | 1.8 TB usable | exFAT | USB-C, direct to MacBook |
+| **Noisy Cricket** | SanDisk 2TB external SSD | 1.8 TB usable | exFAT | USB-C via iVanky dock when MacBook is docked; direct USB-C when mobile |
+
+---
+
+## 🎯 Role
+
+- **Carbonizer** — mobile working copy of the full photo library and active project files. Primary external drive; stays with the MacBook whether docked or mobile.
+- **Noisy Cricket** — 1:1 clone of Carbonizer. Disaster-recovery copy; never the drive worked off of directly.
+
+Photo and project content on these drives is **authoritative in the moment** (roughly the current year and recent past). The NAS is authoritative for anything older; see [Authority rules](#authority-rules-target-state).
+
+---
+
+## 🗂️ Folder Layout (Carbonizer; Noisy Cricket is a clone)
+
+```
+/Volumes/Carbonizer/
+├── Music/                              # Music files
+├── Photos/
+│   ├── _CCC SafetyNet/                 # Carbon Copy Cloner quarantine (replaced/deleted files)
+│   ├── Drone/                          # Drone archives
+│   ├── Photo Files/                    # Primary photo archive
+│   ├── Photos Library.photoslibrary/   # Apple Photos library (clone of Mac's — verify)
+│   └── Remote Year/                    # Travel photos
+├── Projects/                           # Active and near-active project files
+└── Remote Year/                        # Additional travel content outside Photos/ (verify whether dupe)
+```
+
+---
+
+## 🔁 Sync & Backup Strategy
+
+| Pair | Tool | Direction | Trigger |
+|---|---|---|---|
+| MacBook `~/Pictures/` → Carbonizer | Carbon Copy Cloner | → | Manual; when both connected and CCC is open |
+| Carbonizer → Noisy Cricket | Carbon Copy Cloner | → | Manual; when both connected and CCC is open |
+| Carbonizer (or Noisy Cricket) → NAS `Media/photos/` | Manual rsync | → | At year close (target state; not consistently executed) |
+
+### Authority rules (target state)
+
+- **Current year:** MacBook `~/Pictures/` and Carbonizer hold the working copies; Noisy Cricket is the offline backup.
+- **Older than ~1 year:** NAS `Media/photos/` is authoritative; SSDs may hold a cached copy but are not the master.
+- **Immich** indexes the NAS archive. Not all older content imported yet; tracked in Plan 0002.
+
+---
+
+## ⚠️ Known Issues / Drift
+
+- **Manual CCC triggering.** Clone runs only when the user remembers to open CCC with both drives mounted. Noisy Cricket can drift behind Carbonizer for unknown stretches.
+- **Both SSDs live onsite.** No offsite rotation — single location = single failure mode (fire, flood, theft).
+- **exFAT filesystem.** No journaling, no POSIX permissions, susceptible to corruption on unclean ejects. Acceptable for Mac/Windows interop but not ideal as a long-term photo archive filesystem.
+- **Year-close archival to NAS.** Documented rule but not executed for 2025; `~/Pictures/2025 Photos/` and Carbonizer both still hold 2025 content.
+- **Apple Photos library duplication.** A `Photos Library.photoslibrary` exists on both MacBook and Carbonizer. Whether Carbonizer's copy is an active CCC clone or a stale snapshot needs verification.
+- **`Remote Year/` appears twice** on Carbonizer (root and under `Photos/`). Verify which is current.
+
+Overall strategy tracked in Plan 0002 (3-2-1 consolidation).
+
+---
+
+## 📝 Notes
+
+- Carbonizer should be mounted whenever the MacBook is docked or in active use.
+- Noisy Cricket mounts via the iVanky dock (docked) or direct USB (mobile).
+- CCC's `_CCC SafetyNet/` folder grows over time; purge periodically when free space tightens.

--- a/docs/plans/0002-data-3-2-1-consolidation.md
+++ b/docs/plans/0002-data-3-2-1-consolidation.md
@@ -273,3 +273,9 @@ Phase 7 (iCloud non-photo cleanup)
 - 2026-04-22 — Phase 1 started: iPhone + iPad Immich backup setup
 - 2026-04-22 — Phase 1 complete: iPhone backup active, iPad deferred, public URL hardened, Immich iGPU enabled
 - 2026-04-22 — Phase 2 scale measured: 24,767 total assets in duplicate groups. Phase 2 tooling drafted: `tools/immich-dedup/classify.py` on branch `feat/immich-dedup`. Framed as a community-submittable improvement to Immich dedup workflow, not just a personal utility.
+- 2026-04-22 — `tools/immich-dedup/` tool set completed: `classify.py` (markdown report, 7 buckets + confidence tiers), `gallery.py` (HTML visual review with embedded thumbnails), `apply.py` (bucket-filtered execution via `/api/duplicates/resolve` with dry-run default + JSONL log + retry-on-timeout). 38 unit tests passing.
+- 2026-04-22 — Classifier refinement iterations: v0 0% classified → v1 95.9% high-confidence (added `rendition_set` + `dominant_keeper` buckets) → v2 97.1% high-confidence (expanded iOS rendition suffix regex to `_[aco]`). Residual `edge_case` shrank from 17,646 → 74 groups.
+- 2026-04-22 — Postgres backup taken on UGREEN: `/volume1/backups/immich-predoc-dedup/pg-20260422-231214.sql.gz` (550 MB). Verified: 62 CREATE TABLEs, valid dump header.
+- 2026-04-22 → 2026-04-23 — Phase 2 execution: canary (heic_jpeg_pair, 8 groups) → rendition_set (~23k groups, one socket-timeout-driven crash on batch 61, fixed via broader exception catch + retry + 300s timeout → resumed) → dominant_keeper → burst → screenshots → edge_case (74 manual in UI). All buckets processed to Immich trash.
+- 2026-04-23 — Phase 2 execution complete: 24,522 duplicate groups resolved (per `apply.log.jsonl`) out of 24,705 starting groups. The ~183 delta is groups that stopped being duplicates mid-process (siblings resolved) plus `edge_case` groups opted out of. Soak period begins.
+- 2026-04-23 — Phase 2 soak period begins. Empty trash at day 7+ to close Phase 2.

--- a/docs/plans/0002-data-3-2-1-consolidation.md
+++ b/docs/plans/0002-data-3-2-1-consolidation.md
@@ -46,6 +46,8 @@ Get the personal-data ecosystem into a 3-2-1-aligned state (3 copies, 2 media ty
 | iCloud | **200 / 200 GB (FULL)** | — | Photos 150.2 GB, Backup 38.3 GB, Messages 7.3 GB, Docs 4.1 GB, Mail 26 MB |
 | Google Drive Personal | 26 / 100 GB | — | Atlas canonical |
 | Google Drive Syntheus | 23 / 60 GB | — | Client work, hard boundary |
+| SanDisk `Carbonizer` (2 TB exFAT SSD) | 1.3 / 1.8 TB | — | Mobile primary photo + projects mirror; Mac ↔ SSD via CCC |
+| SanDisk `Noisy Cricket` (2 TB exFAT SSD) | ~same (1:1 clone) | — | CCC clone of Carbonizer; currently onsite — offsite path in Plan 0005 |
 
 ### Irreplaceable vs replaceable data
 
@@ -94,15 +96,23 @@ Get the personal-data ecosystem into a 3-2-1-aligned state (3 copies, 2 media ty
 
 **Goal:** Immich library is clean, deduplicated, and the declared source of truth before emptying iCloud.
 
-**Steps:**
-1. Run Immich's built-in duplicate detection (`immich-duplicate-finder` job)
-2. Review duplicate groups; remove 100–200 GB of dupes/trash estimated
-3. Verify no orphaned thumbnails or broken external library references
-4. Tag/album strategy: establish year folders (`2015/`, `2016/`, ...) for external library structure if used
-5. Back up the Immich Postgres + config **before any destructive action in Phase 3** (UGREEN → Synology once Phase 4 is ready, or manual export in the interim)
-6. Declare: Immich = photo master. iCloud = downstream curated subset only.
+**Scale as of 2026-04-22:** Immich reports 24,767 total assets across duplicate groups. Manual review is off the table; triage requires tooling.
 
-**Exit criteria:** Immich dedup pass complete. Postgres + config backup taken. Library size documented.
+**Tool:** `tools/immich-dedup/classify.py` (added 2026-04-22 on branch `feat/immich-dedup`). Read-only classifier that buckets the `/duplicates` output by handling type (`bit_identical`, `heic_jpeg_pair`, `live_photo_pair`, `burst`, `screenshots`, `edge_case`). Writes nothing. Designed to be extracted into its own repo / submitted to the Immich community if v0 earns its keep.
+
+**Steps:**
+1. **Postgres + config backup FIRST** — before any destructive action, on UGREEN: `docker exec immich_postgres pg_dumpall -U postgres | gzip > /volume1/backups/immich-predoc-dedup/pg-$(date +%Y%m%d-%H%M%S).sql.gz`. Only rollback path if the dedup script misbehaves against 24k+ assets.
+2. **Run `classify.py`** to get the bucket breakdown. Output is a markdown report.
+3. **Decide handling per bucket:**
+   - `bit_identical` / `heic_jpeg_pair` / `screenshots`: bulk-accept Immich's `suggestedKeepAssetIds` via `POST /api/duplicates/resolve` (or Immich's UI "Duplicate all" with a spot-check).
+   - `burst`: bulk-accept with 5% human sample-check.
+   - `live_photo_pair`: consider stacking via Immich's stack feature instead of deleting.
+   - `edge_case`: human review. If this bucket is large, build a lightweight review UI (10 groups at a time) as a second phase of the tool.
+4. **Execute to trash** (soft delete; 30-day recovery). Log every action.
+5. **7-day soak in trash** — chance to spot regrets before hard delete.
+6. **Empty trash, verify, declare Immich = master-of-record.**
+
+**Exit criteria:** Immich dedup pass complete. Postgres + config backup taken. Library size documented in plan status log.
 
 ### Phase 3 — Empty iCloud Photos
 
@@ -262,3 +272,4 @@ Phase 7 (iCloud non-photo cleanup)
 - 2026-04-22 — Plan drafted from session inventory and answered blocking questions
 - 2026-04-22 — Phase 1 started: iPhone + iPad Immich backup setup
 - 2026-04-22 — Phase 1 complete: iPhone backup active, iPad deferred, public URL hardened, Immich iGPU enabled
+- 2026-04-22 — Phase 2 scale measured: 24,767 total assets in duplicate groups. Phase 2 tooling drafted: `tools/immich-dedup/classify.py` on branch `feat/immich-dedup`. Framed as a community-submittable improvement to Immich dedup workflow, not just a personal utility.

--- a/docs/plans/0003-zsh-prompt-setup.md
+++ b/docs/plans/0003-zsh-prompt-setup.md
@@ -1,6 +1,6 @@
 # Plan 0003 — zsh prompt setup (Powerlevel10k + Atlas sync)
 
-**Status:** In Progress
+**Status:** Complete
 **Issue:** — (create on session-end)
 **Created:** 2026-04-22
 
@@ -186,69 +186,72 @@ Choose any emoji pair — success≠error is the key invariant so failed command
 
 Reload: `exec zsh`.
 
-### Phase 4 — Move to Atlas + symlink (do NOT defer)
+### Phase 4 — Snapshot to Atlas (copies, not symlinks)
 
-Three files go to Atlas: `~/.zshrc`, `~/.p10k.zsh`, and `~/.config/ghostty/config`. Different target subfolders because they're conceptually different config surfaces.
+**Design pivot (2026-04-22):** originally this phase used symlinks. Switched to copies + a sync script instead. Rationale: cloud-sync daemons should not sit in the critical path of shell startup. Live dotfiles stay under `$HOME`; Atlas holds snapshots refreshed via an explicit command. Drift risk is the known tradeoff, mitigated by a `--check` mode that can be wired into session-start later.
+
+Three live files, three Atlas snapshots:
+
+| Live path | Atlas snapshot |
+|---|---|
+| `~/.zshrc` | `~/Atlas/config/shell/zshrc` |
+| `~/.p10k.zsh` | `~/Atlas/config/shell/p10k.zsh` |
+| `~/.config/ghostty/config` | `~/Atlas/config/terminal/ghostty-config` |
+
+**Initial snapshot:**
 
 ```sh
-# Shell config
-mkdir -p ~/Atlas/config/shell
-mv ~/.zshrc ~/Atlas/config/shell/zshrc
-mv ~/.p10k.zsh ~/Atlas/config/shell/p10k.zsh
-ln -s ~/Atlas/config/shell/zshrc ~/.zshrc
-ln -s ~/Atlas/config/shell/p10k.zsh ~/.p10k.zsh
-
-# Terminal (Ghostty) config
-mkdir -p ~/Atlas/config/terminal
-mv ~/.config/ghostty/config ~/Atlas/config/terminal/ghostty-config
-ln -s ~/Atlas/config/terminal/ghostty-config ~/.config/ghostty/config
+mkdir -p ~/Atlas/config/shell ~/Atlas/config/terminal
+cp ~/.zshrc ~/Atlas/config/shell/zshrc
+cp ~/.p10k.zsh ~/Atlas/config/shell/p10k.zsh
+cp ~/.config/ghostty/config ~/Atlas/config/terminal/ghostty-config
 ```
 
-Verify:
+**Ongoing sync** — see `environment/sync-shell-config.sh`:
+
+- Default: copy forward ($HOME → Atlas), byte-compare to skip unchanged files.
+- `--check`: report drift only, exit 1 if any file differs. Non-writing.
+
+Run after any edit to a tracked dotfile.
+
+**Verify:**
+
 ```sh
-ls -la ~/.zshrc ~/.p10k.zsh ~/.config/ghostty/config
+./environment/sync-shell-config.sh --check
 ```
-All three must show `-> /Users/andrewlee/Atlas/config/...`.
 
-Open a new Ghostty window. Confirm prompt and theme look identical to pre-symlink state. If yes, sync works.
+Should report all three files `up to date`.
 
-### Phase 5 — Update folder schema
+### Phase 5 — Folder schema
 
-Two new subfolders under `~/Atlas/config/` need to be added to `folder-schemas/config.md`:
+`folder-schemas/config.md` did not previously exist — created in this phase. Covers all `~/Atlas/config/` subfolders (`ai`, `apps`, `desktop-images`, `keys`, `settings`, `shortcuts`, `templates`, `themes`) plus the two new ones from this plan:
 
-- `shell/` — "Shell config (zshrc, p10k.zsh) symlinked into `$HOME` on each workstation"
-- `terminal/` — "Terminal emulator config (e.g., Ghostty) symlinked into `~/.config/<app>/` on each workstation"
+- `shell/` — shell dotfile snapshots, synced via `environment/sync-shell-config.sh`
+- `terminal/` — terminal emulator config snapshots, same sync script
 
-Slot alongside existing entries: `ai`, `apps`, `desktop-images`, `keys`, `settings`, `shortcuts`, `templates`, `themes`.
+Schema also documents the one-way sync model and the anti-pattern of symlinking live dotfiles into a cloud-synced path.
 
-### Phase 6 — Document setup for new machines
+### Phase 6 — Document new-machine setup
 
-Add `environment/shell-setup.md` (or section in existing env docs) covering the minimum steps to make a new workstation match this one:
+`environment/shell-setup.md` covers the Atlas → `$HOME` restore direction: brew installs (p10k, Meslo Nerd Font), `cp` from Atlas snapshots to the live dotfile paths, `exec zsh`, verification via prompt visual + Nerd Font glyph test. Also documents the ongoing sync workflow pointing at `sync-shell-config.sh`.
 
-1. `brew install powerlevel10k`
-2. `brew install --cask font-meslo-lg-nerd-font`
-3. `ln -s ~/Atlas/config/shell/zshrc ~/.zshrc`
-4. `ln -s ~/Atlas/config/shell/p10k.zsh ~/.p10k.zsh`
-5. `mkdir -p ~/.config/ghostty && ln -s ~/Atlas/config/terminal/ghostty-config ~/.config/ghostty/config`
-6. Install Ghostty (from ghostty.org — not brew-cask-available on all setups; worth checking)
-7. `exec zsh`
-
-Phases 5 and 6 can be deferred to the next session without blocking the prompt working.
+The restore direction is manual by design — a deliberate, first-time-only copy onto a new machine. The sync script is strictly one-way ($HOME → Atlas) so it can never clobber a live dotfile.
 
 ---
 
 ## Risks / open questions
 
 - **Font install fails / Ghostty can't find it** — unlikely but check with `fc-list | grep -i meslo` after the cask install. Fallback: download from the p10k repo manually.
-- **Existing `~/.zshrc` has user content not just the p10k source line** — the `mv` in Phase 4 preserves everything. Verify with `cat ~/Atlas/config/shell/zshrc` before the symlink if unsure.
+- **Drift between live dotfile and Atlas snapshot** — copy approach instead of symlink means edits won't auto-propagate. Mitigation: `environment/sync-shell-config.sh --check` reports drift and can be wired into a session-start or shell-exit hook later.
 - **Secondary workstation is Windows** — symlinks work on WSL but native PowerShell needs a different strategy. Out of scope; p10k on WSL reads the same Atlas-synced config if WSL mounts `~/Atlas/` (Google Drive for Desktop on Windows).
 - **Transient prompt + multi-line commands** — occasionally collapses a long edited command awkwardly. If it bothers, set `POWERLEVEL9K_TRANSIENT_PROMPT=same-dir` (collapse only when dir is same) or `off`.
 
 ## Exit criteria
 
-- [ ] `exec zsh` shows two-line p10k prompt with rainbow segments
-- [ ] `andrewlee@AM2` (or equivalent user@host segment) is visibly colored and distinct from command text
-- [ ] Path truncates as `~/w/p/life-atlas` style
-- [ ] Emoji prompt char appears; changes between success and error states
-- [ ] `ls -la ~/.zshrc ~/.p10k.zsh ~/.config/ghostty/config` shows all three as symlinks into `~/Atlas/config/`
-- [ ] Restart Ghostty, open new shell, prompt + theme still work (sync persisted)
+- [x] `exec zsh` shows two-line p10k prompt with rainbow segments
+- [x] `andrewlee@AM2` (or equivalent user@host segment) is visibly colored and distinct from command text
+- [x] Path truncates as `~/w/p/life-atlas` style
+- [~] Emoji prompt char — **dropped** 2026-04-22; user chose to keep the default chars
+- [x] `~/Atlas/config/shell/{zshrc,p10k.zsh}` and `~/Atlas/config/terminal/ghostty-config` snapshots exist
+- [x] `environment/sync-shell-config.sh --check` reports all three files up to date
+- [x] `folder-schemas/config.md` and `environment/shell-setup.md` document the model

--- a/docs/plans/0004-photo-quality-curation-app.md
+++ b/docs/plans/0004-photo-quality-curation-app.md
@@ -1,0 +1,242 @@
+# Plan 0004 — Photo quality curation app (exploration)
+
+**Status:** Exploration — research only, no build commitment
+**Issue:** — (create on session-end)
+**Created:** 2026-04-22
+
+---
+
+## Goal
+
+Decide whether to build — and if so, scope — a purpose-built tool for ongoing quality curation of a personal photo library. The tool would sit on top of Immich and address the gap between "everything in Immich" and "only the photos that meaningfully represent my life." Output of this plan is a go / no-go decision plus a build plan if go.
+
+## Background
+
+This plan was surfaced during plan 0002 Phase 2 (Immich dedup). Dedup solves redundancy — same photo appearing multiple times — but does nothing for the bigger problem: a photo library that has grown past the owner's ability to manually curate for quality, meaning, or shareability. Even after dedup, the library contains:
+
+- Low-quality shots (blurry, closed eyes, bad exposure, accidental captures)
+- Junk (screenshots, receipts, document scans, app exports)
+- Low-signal volume (10 nearly-identical shots of the same subject, kept "just in case")
+- The small fraction of actually memorable images buried in the noise
+
+The owner wants this library to be **continuously curated** — not a one-time sweep, but an ongoing flow where new captures get triaged into quality tiers, and the library trends toward "only what's worth keeping" over time. Mobile-first, because that's where the owner is when they have spare minutes to prune.
+
+## Scope of this exploration
+
+- **In:**
+  - Competitive landscape survey (see placeholder section below; filled by research agent)
+  - Problem surface — what's actually painful today about personal photo libraries
+  - Target experience sketch (not committed design — just enough to evaluate viability)
+  - Architecture sketch — what plugs into Immich, what needs to be built from scratch
+  - Differentiation hypothesis — what this tool could do that existing tools don't
+  - Build / no-build decision, with cost estimate if build
+- **Out:**
+  - Any code
+  - Detailed UI design
+  - Backend implementation
+  - Model selection / training
+  - Decisions about distribution (self-host only vs. eventual SaaS) — premature until viability clear
+
+## Problem surface
+
+The owner's personal library is large enough that manual curation is not tractable. Key pain points:
+
+1. **Quality drift**: the library grows faster than it's curated. Low-quality shots accumulate. Finding good photos gets harder over time.
+2. **Junk clutter**: screenshots, receipts, and document scans are first-class citizens in the timeline alongside memories. They're easy to capture and hard to prune at scale.
+3. **Burst/near-dup bloat**: "I took 8 shots to get one good one; I kept all 8." Multiplied across years, this is most of the library.
+4. **Discoverability collapse**: the best photos are buried. "Show me the 20 photos from 2022 I'd want to show someone" is a question the current library cannot answer.
+5. **Review friction**: the tools that exist require desktop sessions with visual review. The owner doesn't sit down to curate; they have 5-minute windows on a phone.
+
+## Target experience (sketch)
+
+- **Mobile-first.** iPhone, primarily — this is where capture happens and where spare-minute curation happens.
+- **Swipe-based review.** Tinder-style: left = trash, right = keep, up = favorite/highlight, down = archive. One photo at a time, full-resolution, fast decisions.
+- **Quality signals surfaced, not hidden.** "This photo is blurry" or "this looks like a receipt" shown inline so the decision is cheap.
+- **Moments surfaced automatically.** The app should be able to say "here are 15 photos from your trip to Maine in June 2025 that I think capture the moments" and let the owner approve / refine → feeds into an auto-generated highlights album.
+- **Ongoing, not batch.** New captures flow through a quality pipeline; low-quality gets flagged for review; high-quality gets tagged for highlights. Owner reviews the flags as a habit, not as a project.
+
+## Architecture sketch (pre-decision)
+
+**Inputs / integrations:**
+- Immich API as source of truth. All reads and writes go through it. The app is a layer on top, not a replacement.
+- Immich already provides: face recognition, CLIP smart search, object tagging.
+
+**Gaps Immich does not fill (these are what the app would add):**
+- Quality scoring (blur, exposure, closed eyes, composition)
+- Junk classification (screenshot, receipt, document)
+- Burst-group clustering + best-of-burst selection
+- Event-significance scoring (which moments warrant highlight surfacing)
+- Mobile-first review UX
+
+**Candidate stack:**
+- **Backend**: Python service running on UGREEN in Docker. Reads from Immich API, runs supplementary ML (OpenCV for blur, small classifiers for screenshots/receipts, face-landmark models for eyes, CLIP for composition / moment scoring), writes augmented metadata back as Immich tags.
+- **Mobile app**: Native Swift (iPhone-first) OR React Native / Expo (cross-platform at some iteration cost). Hits the backend over Tailscale. No direct Immich API calls from the app — backend mediates so auth stays server-side.
+- **Sync model**: one-way, backend → Immich tags. App makes decisions by reading tags + Immich metadata; writes back (trash, favorite, star rating) via Immich API.
+
+Open architectural questions captured in **Open questions** below.
+
+## Competitive landscape
+
+*Researched 2026-04-22. Agent worked from training knowledge (early 2026), not live web sources — spot-check any specific product before committing to build decisions.*
+
+### 1. Self-hosted photo managers
+
+| Product | Self-hosted | Mobile-first | Immich-compat |
+|---|---|---|---|
+| Immich | yes | yes | — |
+| PhotoPrism | yes | partial | no |
+| LibrePhotos | yes | no | no |
+| Ente | partial (E2E cloud, self-host option) | yes | no |
+| Mylio Photos | no (local-first, P2P sync) | yes | no |
+| Photoview | yes | no | no |
+
+- **Immich** — Excellent ingest, face recognition, CLIP-based semantic search, "Memories" by date; missing native quality scoring, burst/near-dup clustering beyond exact hash, and a review-UI for keep/delete swipe flows.
+- **PhotoPrism** — Strong tagging and TensorFlow classification; has a basic quality score (exposure/blur heuristic) and "stacks" for similar photos. Missing mobile-first review and moments surfacing beyond calendar/map.
+- **LibrePhotos** — Event auto-generation, face clustering; slow development, minimal mobile, no quality scoring.
+- **Ente** — E2E-encrypted; has magic search and memories, but self-host is underinvested vs. hosted. Doesn't scan for junk/blur.
+- **Mylio Photos** — Local-first multi-device sync, "SpaceSaver," duplicate detection. Proprietary, not Immich-compatible, no true AI quality scoring.
+- **Photoview** — Lightweight viewer; essentially no AI curation features.
+
+**Gap in this category:** none ship a "triage this library" workflow with model-scored blur/eyes-closed/composition quality and a mobile review loop.
+
+### 2. Consumer photo products with AI curation
+
+| Product | Self-hosted | Mobile-first | Immich-compat |
+|---|---|---|---|
+| Google Photos | no | yes | no |
+| Apple Photos | no (iCloud) | yes | no |
+| Amazon Photos | no | yes | no |
+| Microsoft Photos | no | partial | no |
+
+- **Google Photos** — Best-in-class Memories, Highlights, Cinematic Photos; asks "archive this screenshot?" and suggests freeing space on low-quality items. Walled garden — cannot operate over an Immich library.
+- **Apple Photos** — For You, Memories (iOS 18/26 refreshed with on-device LLM), Duplicates detector, auto-sorted Screenshots album. Locked to iCloud, no API to act on external libraries, no bulk pruning UX.
+- **Amazon Photos** — Basic Memories; behind the others.
+- **Microsoft Photos** — Weakest of the group for surfacing.
+
+**What they can't do for a self-hosted user:** operate on files they don't host, expose quality scores as data, give the user agency to bulk-prune programmatically.
+
+### 3. Professional / photographer culling tools
+
+| Product | Self-hosted | Mobile-first | API available |
+|---|---|---|---|
+| Aftershoot | desktop app | no | no |
+| Narrative Select | desktop app | no | no |
+| FilterPixel | desktop app | no | no |
+| Cull.ai | cloud | no | partial (enterprise) |
+| Photo Mechanic | desktop app | no | no |
+
+- **Aftershoot** — Market leader for wedding/event culling; excellent blur, closed-eyes, duplicate/burst detection, composition score. Desktop-only, per-shoot workflow, not built for 100k libraries or mobile.
+- **Narrative Select / FilterPixel** — Fast AI-assisted keyboard cull, desktop-bound, no API.
+- **Cull.ai** — Cloud-based, enterprise API inquiries but no documented public SDK.
+- **Photo Mechanic** — Manual ingest gold standard; no AI quality scoring.
+
+**Takeaway:** the underlying tech (blur / eyes / burst) is solved and commoditized. None are repurposable as a library-scale service, but the OSS equivalents are all available: OpenCV Laplacian blur variance, MediaPipe face-mesh eye-open detection, perceptual hashing, LAION aesthetic predictors v2/v2.5, CLIP-based quality heads.
+
+### 4. Dedicated dedup / junk cleaners
+
+| Product | Self-hosted | Mobile-first | Immich-compat |
+|---|---|---|---|
+| Gemini 2 (MacPaw) | local | no | no |
+| PhotoSweeper | local | no | no |
+| Duplicate Photos Fixer | local | partial | no |
+| Remo Duplicate Photos Remover | local | partial | no |
+| iMyFone Umate | local | no (iOS cleaner) | no |
+
+- **Gemini 2 / PhotoSweeper** — Perceptual-hash dedup on a Mac filesystem; no quality scoring, no moments, no Immich awareness.
+- **Mobile cleaners** — Focus on iOS Photos, clean up similar / screenshots; shallow AI (mostly pHash + basic blur); don't touch a server library.
+
+**Scope vs. need:** these solve ~20% of the problem (exact/near dupes). Subjective quality, burst best-of, and moment surfacing are all out of scope.
+
+### 5. AI-first photo startups / newer entrants (2024-2026)
+
+| Product | Self-hosted | Mobile-first | Immich-compat |
+|---|---|---|---|
+| Memento (memento.photos) | no | yes | no |
+| Journey | no | yes | no |
+| Rewind.ai (photos feature) | partial (local index) | no | no |
+| Slideshow.fm | no | yes | no |
+| Lapse / 1Second Everyday | no | yes | no |
+
+- **Memento** — AI-generated memory reels from camera roll; consumer-only.
+- **Journey / Slideshow** — Auto-generate shareable recap videos; export-heavy, pruning-light.
+- **Rewind** — Local index of digital life including screenshots; adjacent, macOS-only, not a photo curator.
+- **Lapse / 1SE** — Capture-side "best moments" products; don't operate on existing libraries.
+- **YC / recent launches** — W24-W25 batches included several "AI photo assistant" plays (Photo AI, Memo, various "Marco Polo for memories" clones). All consumer-SaaS, none self-hostable, none with Immich integration. **This space is being pitched repeatedly but no one has shipped for the self-host audience.**
+
+### 6. Open-source tools adjacent
+
+| Product | Self-hosted | Mobile-first | Immich-compat |
+|---|---|---|---|
+| digiKam | yes | no | no |
+| Shotwell | yes | no | no |
+| darktable | yes | no | no |
+| czkawka | yes | no | no |
+| imagededup (idealo) | library | — | library |
+| dupeGuru | yes | no | no |
+
+- **digiKam** — Mature desktop manager; basic quality scoring (blur/noise/compression/exposure heuristics), face tagging, geotag. Desktop-bound, heavyweight, no mobile.
+- **czkawka / dupeGuru** — Fast CLI/desktop dedup; no quality dimension.
+- **imagededup** — Python library, pHash/dHash/CNN-based near-dup; useful building block, not a product.
+- **GitHub "photo curation"** — handful of hobby scripts; none production-grade.
+
+### Immich plugin ecosystem
+
+- **immich-go / immich-cli** — Batch ingest, useful for automation.
+- **immich-power-tools** (community) — Bulk operations, duplicate review UX improvements. Closest existing third-party curation tooling on Immich today. **Worth auditing before build to see what's already covered.**
+- **immich-ml / external ML workers** — Immich's ML container is swappable; custom CLIP or quality models can be dropped in. Most important plugin surface for anyone building in this space.
+
+The Immich plugin ecosystem is early — no mature third-party marketplace, but the API is stable enough to build against and the community is explicitly inviting ML extensions.
+
+### Gaps most consistently unfilled
+
+These are what no current product delivers together — the defensible lane:
+
+1. **Self-hosted + model-scored quality + mobile swipe-review in one product.** Every competitor has at most two of the three. **This is the core open lane.**
+2. **Cross-library curation across iCloud *and* Immich.** Unaddressed — but probably out of scope given plan 0002's Immich-as-master direction.
+3. **Bulk-scale triage UX.** Consumer apps surface 10 memories a day; pro tools cull a 2k-image shoot. Nothing is designed for a human to make meaningful dent in a 100k backlog in 5-minute mobile sessions (progress visibility, batch actions, "keep all like this," undo-safety).
+4. **Quality scores as first-class, inspectable data.** Every closed product hides its scores. A self-hoster wants to query "show me all photos scored <0.2 from 2019" and act in bulk. No product exposes this.
+5. **Moments surfacing that respects user-defined criteria.** Google/Apple Memories are black boxes. A "best of this trip / this kid / this year" that the user can tune (weights for faces, aesthetics, rarity of subject) doesn't exist in self-hosted or consumer form.
+
+**Verdict:** the "AI surfaces your best moments" space is crowded for consumer cloud users and empty for self-hosted users. The defensible build is at the intersection of Immich's API, commoditized quality-scoring models, and a mobile-first triage UX — a space where no current product competes.
+
+## Differentiation hypothesis (post-research)
+
+Research confirmed all four pre-research hypotheses and surfaced a fifth. The defensible lane is the intersection of:
+
+1. **Self-hosted, Immich-native.** Every consumer product (Google, Apple, Amazon, Microsoft) is walled. Every self-hosted manager (Immich, PhotoPrism, LibrePhotos) is missing quality scoring or mobile review. No one sits in both camps.
+2. **Mobile-first pruning with full-res access.** Pro cullers are desktop (Aftershoot, Narrative); self-hosted is desktop or read-only mobile. The 5-minute-on-iPhone flow is not served anywhere.
+3. **Continuous, not batch.** Consumer apps surface ~10 memories a day passively. Pro tools cull a 2k-image shoot once. Nothing is designed for an ongoing 100k-library triage habit.
+4. **AI-surfaced moments, user-tunable.** Google/Apple Memories are black boxes. No self-hosted equivalent lets the owner tune weights (more family, less food, etc.).
+5. **Quality scores as first-class, queryable data.** (New from research.) Every closed product hides scores. A self-hoster would want to query "show me all photos scored <0.2 from 2019" and act in bulk. Nothing exposes this.
+
+**Verdict (from research):** the "AI surfaces your best moments" space is crowded for consumer-cloud users and empty for self-hosted users. The defensible build sits at Immich's API + commoditized quality-scoring models (LAION aesthetic v2.5, CLIP quality heads, MediaPipe face landmarks, OpenCV blur) + mobile-first triage UX.
+
+**Caveat to verify before committing:** `immich-power-tools` (community project) is the closest existing third-party curation tooling on Immich. **Audit it before investing in build** — if it already covers the boring 40-60%, the build scope shrinks considerably.
+
+## Open questions
+
+- [x] Research: what's the competitive landscape, and where are the real gaps? Done 2026-04-22.
+- [ ] **Audit `immich-power-tools`** — closest existing community tool on Immich; need to know what it already covers before scoping build.
+- [ ] Is this genuinely a product, or a personal tool? The owner's framing is "build for myself but well enough it could be more." Decision deferred until post-research.
+- [ ] Model choice for quality scoring: off-the-shelf (MediaPipe face landmarks, CLIP for composition) vs. a purpose-trained small model? Off-the-shelf is cheaper; training is a time sink that may not pay off for v1.
+- [ ] Mobile stack: native Swift (best UX, iOS-only) vs. React Native (cross-platform, some UX cost). Depends on whether secondary workstation / iPad is in scope for v1 or v2.
+- [ ] Authentication / API surface: where does the app get its Immich credentials? Re-use the owner's personal API key, or proxy through a dedicated backend account?
+- [ ] Rating / tagging schema: what tag names and rating conventions will the app write to Immich? Needs to be stable across app versions and not conflict with manually-added tags.
+- [ ] Offline behavior: app usable when Tailscale is flaky? Probably needs a local cache of pending decisions.
+- [ ] iCloud / Google Photos integration — is the tool Immich-only, or does it also help the owner prune iCloud? Given plan 0002's Immich-as-master direction, probably Immich-only.
+
+## Decision gate
+
+This exploration ends with a go / no-go decision. Criteria for go:
+
+1. Research confirms the differentiation hypotheses — there isn't an existing tool that covers Immich-native + mobile-first + continuous curation + AI moments.
+2. The architecture sketch survives scrutiny — no showstopper (Immich API too thin, ML models too expensive to run on UGREEN, etc.).
+3. The owner wants to build it. This is a personal project with potential product upside; motivation matters.
+
+If go: this plan closes, and plan 0005 (or later) opens as the build plan.
+
+## Status log
+
+- 2026-04-22 — Exploration plan drafted. Research agent dispatched for competitive landscape.
+- 2026-04-22 — Competitive landscape integrated. Five gaps identified; all pre-research hypotheses validated. Open: audit `immich-power-tools` before committing to build.
+- 2026-04-22 — Build-commitment deferred. Owner: low conviction on building the full app. Near-term work (Immich dedup classifier + possibly a lightweight 10-at-a-time review UI) to stay in life-atlas on branch `feat/immich-dedup`; extract to its own repo only if scope outgrows "lightweight."

--- a/docs/plans/0005-photo-project-lifecycle.md
+++ b/docs/plans/0005-photo-project-lifecycle.md
@@ -1,0 +1,298 @@
+# Plan 0005 — Photo + project lifecycle operating model
+
+**Status:** In Progress
+**Issue:** — (create on session-end)
+**Created:** 2026-04-22
+**Depends on:** Plan 0002 (data 3-2-1 consolidation) — complementary, not blocking
+
+---
+
+## Goal
+
+Establish a durable, automated operating model for photos and project files: continuous backup off the Mac, automated mirror to the external SSDs, a real offsite copy at brother's UGREEN DXP6800 in Vermont, and a year-close gate that uses Immich indexing as the forcing function. Plan 0002 addresses the iCloud/Immich crisis; this plan addresses the day-to-day pipeline that keeps the crisis from recurring.
+
+## Scope
+
+- **In:**
+  - Offsite replication Peddocks2 → brother's UGREEN DXP6800 over Tailscale
+  - Noisy Cricket physical rotation to brother's (bootstrap + standing redundant offsite)
+  - Continuous (hourly or on-change) Mac → NAS backup of `~/Pictures/` and project paths, beyond Time Machine
+  - Carbon Copy Cloner automation (on-mount or scheduled)
+  - Year-close gate: archived only when Carbonizer + Noisy Cricket + NAS + brother's UGREEN + Immich all have verified copies
+  - Carbonizer Apple Photos library disposal (201 GB reclaim on each SSD)
+  - exFAT hygiene playbook (eject discipline, monthly First Aid, cruft cleanup)
+  - Mac ↔ Carbonizer authority reconciliation (Carbonizer currently has content Mac does not)
+  - Project files as first-class archive target (same tiers as photos)
+  - Post-M5-upgrade adjustments
+- **Out:**
+  - Immich dedup / iCloud unblock (Plan 0002)
+  - NAS RAID rebuild (Plan 0002 Phase 4)
+  - Obsidian vault sync (Plan 0002 Phase 5)
+  - Filesystem migration off exFAT — user declined (Windows read compatibility required)
+  - Project workflow / "shipping" process itself (tooling, deadlines, publish flow) — separate concern
+
+---
+
+## Inventory snapshot (2026-04-22)
+
+### Disk usage
+
+| Path | Size | Notes |
+|---|---|---|
+| MacBook internal SSD (Data volume) | 805 / 926 GB used, **69 GB free (93% full)** | Blocks Finder iOS backups; forces aggressive archival until M5 upgrade |
+| `~/Pictures/2025 Photos/` | 246 GB | Mac copy of current year; 38 GB behind Carbonizer |
+| `~/Pictures/2026 Photos/` | 7.3 GB | Current year in progress |
+| `~/Pictures/Lightroom Library.lrlibrary/` | 6.2 GB | Lightroom catalog |
+| `~/Pictures/Photos Library.photoslibrary/` | ~0.5 GB | Effectively empty; not used as creative surface |
+| `~/Pictures/YYYY Photos/` | 32 KB | Template stub — delete |
+| Carbonizer (SanDisk 2TB exFAT) | **1.3 TB used / 502 GB free (74%)** | Primary external working mirror |
+| `/Volumes/Carbonizer/Photos/Photo Files/2024 Photos/` | 546 GB | **Only on Carbonizer + Noisy Cricket — single-location risk** |
+| `/Volumes/Carbonizer/Photos/Photo Files/2025 Photos/` | 284 GB | 38 GB more than Mac — authority drift |
+| `/Volumes/Carbonizer/Photos/Photos Library.photoslibrary/` | 201 GB | Old Apple Photos library; disposable per user |
+| `/Volumes/Carbonizer/Photos/Remote Year/` | 106 GB | Travel archive |
+| `/Volumes/Carbonizer/Remote Year/` (root) | 94 GB | Duplicate of the above? — verify |
+| `/Volumes/Carbonizer/Photos/Drone/` | 16 GB | Drone archive |
+| `/Volumes/Carbonizer/Music/` | 97 GB | |
+| `/Volumes/Carbonizer/Projects/` | 1 GB | Currently tiny; will grow as project focus increases |
+| `/Volumes/Carbonizer/Photos/_CCC SafetyNet/` | 1.2 GB | CCC's quarantine; periodically purge |
+| `/Volumes/Carbonizer/Photos/Photos Library.photoslibrary/resources_AM2.local_*_CaseConflict` | ~21 GB (8 dirs) | Cruft from exFAT case-insensitive collision during a 2024-07-01 sync; delete |
+| Noisy Cricket | unknown; 1:1 clone assumed | Not currently mounted |
+
+### Current copy topology (photos)
+
+```
+Mac ~/Pictures/                    (2025-2026 only; 2024 not present)
+  └─ Carbonizer (onsite SSD)       (ALL years + Remote Year + old Apple Photos library)
+       └─ Noisy Cricket            (1:1 clone, onsite)
+
+NAS Media/photos/                  (not yet populated for 2024 or 2025)
+Immich                             (partial; Plan 0002 Phase 2 dedup in progress)
+Brother's UGREEN DXP6800           (not yet connected)
+```
+
+Everything physically onsite except Immich (still onsite — same NAS). **Zero true offsite copies today.**
+
+---
+
+## Approach
+
+### Phase 1 — Baseline, reconciliation, and drift cleanup
+
+**Goal:** Know what exists where; resolve authority ambiguity; remove known cruft.
+
+**Steps:**
+1. **Measure `Carbonizer_BU`.** `sudo du -sh /Volumes/Carbonizer_BU` (current shell has permission denied; needs sudo). Then `du -h -d 2 /Volumes/Carbonizer_BU 2>/dev/null | sort -h` for subfolder breakdown. This is the actual CCC UGREEN backup target; we've never seen its contents.
+2. **Reconcile `Media/photos/` vs `Carbonizer_BU` on NAS.** Two parallel NAS photo locations exist. `Media/photos/` has ~612 GB (including 233 GB of 2024, 93 GB Remote Year, 187 GB `archive/`) put there by some non-CCC process. `Carbonizer_BU` is CCC's target. Decide which is authoritative and consolidate, or document why both must persist.
+3. **Reconcile 2025 Photos authority.** Diff Mac `~/Pictures/2025 Photos/` (246 GB) vs. Carbonizer `Photo Files/2025 Photos/` (284 GB). The 38 GB extra on Carbonizer is likely retained-deletion content (pre-Mac-cleanup state). Decide: delete from Carbonizer to match Mac, or keep as extra safety layer? User preference.
+4. **Audit the 313 GB `_CCC SafetyNet/` inside Carbonizer's 2024 Photos.** List the dated subfolders; spot-check whether content is intentional-cull (bad shots culled from Mac) or accidental-deletion (content user wants back). If all intentional culls, safe to purge to reclaim 313 GB on Carbonizer.
+5. **Audit Cricket's 195 GB root-level `_CCC SafetyNet/`.** Same question — historical orphans worth keeping or safe to reclaim?
+6. **Verify `Remote Year/` duplication** on Carbonizer (root 94 GB vs. Photos/ 106 GB). Likely one is stale. Delete the stale copy.
+7. **Investigate `/Volumes/NoisyCrick/Media to Sort/`** (192 GB, not on Carbonizer). Decide: integrate into Carbonizer workflow, archive to NAS, or delete.
+8. **Delete `~/Pictures/YYYY Photos/`** template stub (32 KB, no content).
+9. **Rename `2025 Photos` → `2025-Photos`** and `2026 Photos` → `2026-Photos` on Mac to match schema and `macos_create_photo_year.sh` output. Update CCC source path in the Mac → Carbonizer task.
+10. **Delete case-conflict cruft on Carbonizer** (`resources_AM2.local_*_CaseConflict` — 8 dirs, ~21 GB). Same on Cricket.
+11. **Bound `_CCC SafetyNet/` retention** in CCC UI (reduce from default 30 days to 7 days) for all four tasks. After retention cap takes effect, audit whether SafetyNet folders shrink as expected.
+
+**Exit criteria:** `Carbonizer_BU` contents documented and reconciled with `Media/photos/`. 2025 Photos authority decided. SafetyNet folders audited for keep-vs-purge decisions. Drift folders resolved. `du -sh` across all tiers recorded in Status log.
+
+### Phase 2 — Reclaim Carbonizer Apple Photos (201 GB)
+
+**Goal:** Free 201 GB per SSD by removing the disposable Apple Photos library clone.
+
+**Steps:**
+1. Confirm no unique data in `/Volumes/Carbonizer/Photos/Photos Library.photoslibrary/` — spot-check exported originals vs. Immich / Carbonizer `Photo Files/`.
+2. Delete `/Volumes/Carbonizer/Photos/Photos Library.photoslibrary/`.
+3. Update CCC task to exclude `.photoslibrary` sources going forward (no chance of re-clone on next Mac → Carbonizer run).
+4. Run CCC Carbonizer → Noisy Cricket so Cricket also reclaims 201 GB. Requires both drives mounted.
+
+**Exit criteria:** 201 GB free on Carbonizer and Noisy Cricket. CCC excludes prevent re-copy. No user-visible loss.
+
+### Phase 3 — CCC automation
+
+**Goal:** Remove "when the user remembers" as the trigger for SSD backups.
+
+**Steps:**
+1. Audit existing CCC task definitions (source/destination, excludes, schedule).
+2. Configure Mac → Carbonizer to run **on volume mount** (CCC supports this — "When the destination is reattached") or on a fixed schedule (e.g., every 2 hours when connected). On-mount is better for the "mobile workflow."
+3. Configure Carbonizer → Noisy Cricket to run **when both volumes are attached**. Gate with a pre-flight check so it doesn't run mid-Carbonizer-write.
+4. Configure CCC email/notification on task failure (CCC's built-in feature).
+5. Disable the "SafetyNet" retention default of 30 days; reduce to 7 days to cap growth.
+6. Test: mount Carbonizer → confirm Mac → Carbonizer triggers within a few minutes; mount Cricket → confirm Carbonizer → Cricket triggers.
+
+**Exit criteria:** Both CCC tasks run automatically on drive mount. Notifications configured. SafetyNet retention bounded. Dry-run succeeded.
+
+### Phase 4 — Continuous Mac → NAS backup
+
+**Goal:** Photos and projects reach the NAS within an hour of creation, independent of Time Machine's schedule.
+
+**Options:**
+
+| Approach | Direction | Real-time? | Setup | Notes |
+|---|---|---|---|---|
+| **rsync + launchd** (Mac-side scheduled) | Mac → NAS, one-way | Hourly / on-change with `fswatch` | Low | Simple, proven, no state. Preferred |
+| **Syncthing** (Mac + UGREEN clients) | Bidirectional | Yes (real-time) | Medium | More moving parts; reconciliation complexity; overkill for one-way |
+| **UGREEN native SMB + Time Machine-frequency tweak** | — | No | Low | TM is hourly; insufficient granularity and no photo-specific tiering |
+| **rclone → NAS SMB** | One-way | Scheduled | Low | Works; no advantage over rsync |
+
+**Recommendation: rsync + launchd.**
+
+**Steps:**
+1. Confirm NAS Media share mount persistence (auto-mount on login via keychain-saved SMB credentials).
+2. Define source paths:
+   - `~/Pictures/*-Photos/` → `NAS/Media/photos-wip/<year>/`
+   - Project paths (see Phase 8) → `NAS/Media/projects/` or similar
+3. Write rsync wrapper script in `environment/` — idempotent, honors `--dry-run`, logs to a rotating file, exits non-zero on failure.
+4. Create launchd plist to run hourly (or use `fswatch` for on-change).
+5. Test with a small path first; then full `~/Pictures/`.
+6. Add a health check: weekly job that compares file counts Mac vs. NAS and alerts on divergence.
+
+**Exit criteria:** New photos in `~/Pictures/` reach NAS within 1 hour. launchd job runs unattended. Weekly health check passes. Failures surface via notification.
+
+### Phase 5 — Offsite via brother's UGREEN DXP6800
+
+**Goal:** Real offsite. Photos + projects replicated to a NAS in a different physical location (VT).
+
+**Dependencies:** Brother's buy-in. Tailscale account on his side (or shared tailnet). Gigabit up/down confirmed (user reports yes).
+
+**Steps:**
+1. Brother sets up Tailscale on his DXP6800 (UGREEN UGOS supports Tailscale natively or via Docker). He joins your tailnet OR you share a tailnet via Tailscale Share.
+2. Establish rsync-over-SSH from Peddocks2 to brother's DXP6800. Test with small sample first.
+3. **Seed via Noisy Cricket physical ship.** Rather than grinding the initial ~1 TB over gigabit, physically ship Noisy Cricket to brother (USPS Priority Mail Express with signature + insurance, or deliver in person on next visit). He copies from Cricket into his UGREEN. This saves ~3 hours of transfer time and ~1 TB of his uplink.
+4. After seed: incremental rsync nightly (Peddocks2 → brother's UGREEN).
+5. Restore drill: request a file from brother's UGREEN, verify content matches Peddocks2.
+6. Document the failure-mode matrix: what happens if Tailscale goes down, brother's NAS dies, Cricket is lost in transit.
+
+**Alternative (if brother declines / delays):** Fall back to **physical Noisy Cricket rotation only** — Cricket lives at brother's, gets swapped quarterly on visits. Less automated but still closes the offsite gap.
+
+**Exit criteria:** Brother's DXP6800 holds a verified copy of Peddocks2 photo + project trees. Nightly incremental rsync running. One restore drill completed.
+
+### Phase 6 — Noisy Cricket rotation policy
+
+**Goal:** Define the steady-state role of Noisy Cricket after Phase 5 seed.
+
+**Options:**
+- **(A) Cricket stays at brother's permanently** as a cold offsite; brother's NAS is the warm offsite. Belt-and-suspenders.
+- **(B) Cricket rotates** — travels back home periodically, gets re-cloned from Carbonizer, travels back to brother's. Cadence matches visit cadence.
+
+**Recommendation: (A).** Cricket becomes a cold disaster-recovery drive at brother's. If both Peddocks2 and brother's UGREEN were to fail simultaneously, Cricket is the last-resort seed. No rotation = no in-transit risk after initial ship. If the user visits often enough that rotation is trivial, (B) is also fine.
+
+**Exit criteria:** Written policy in `device-schemas/external-ssds.md`. User committed to a choice.
+
+### Phase 7 — Year-close gate
+
+**Goal:** Formalize the rule for when `YYYY-Photos/` can be removed from Mac.
+
+**Gate criteria (all must be true):**
+- Full copy verified on Carbonizer
+- Full copy verified on Noisy Cricket (or brother's UGREEN post-seed)
+- Full copy verified on NAS `Media/photos/YYYY/`
+- Fully indexed in Immich (all files searchable; per-asset count matches source)
+- Verified via checksum sample (random 5% of files, hashes match across tiers)
+
+**Steps:**
+1. Write `environment/year-close-check.sh` — takes a year, walks the gate criteria, reports pass/fail per tier.
+2. Pilot on 2024 Photos first (already off Mac; verify it satisfies the gate against current NAS + Immich state, or surface the gap).
+3. Once 2024 verified, pilot on 2025 Photos (this year becomes the first "archive in flight" to remove from Mac).
+4. Document as a runbook in `environment/` or `docs/`.
+
+**Exit criteria:** `year-close-check.sh` exists and is idempotent. 2024 Photos passes or gap is documented. 2025 Photos ready for archival when the year closes.
+
+### Phase 8 — Projects as first-class archive
+
+**Goal:** Project files get the same backup tiers as photos.
+
+**Steps:**
+1. Identify project home paths on Mac (TBD — likely `~/workspace/` for code, and something else for creative projects). Open question below.
+2. Decide NAS target path (`Media/projects/`, `personal_folder/projects/`, or a new share).
+3. Fold into Phase 4 continuous backup (rsync includes project paths).
+4. Fold into Phase 5 offsite (brother's UGREEN includes project paths).
+5. Update `folder-schemas/` to document the project backup topology.
+
+**Exit criteria:** Project paths reach NAS and brother's UGREEN on the same schedule as photos. Documented.
+
+### Phase 9 — exFAT hygiene playbook
+
+**Goal:** Minimize corruption risk on exFAT SSDs given the user's filesystem choice.
+
+**Steps:**
+1. Add to `device-schemas/external-ssds.md`:
+   - **Eject discipline:** always `diskutil eject` (or Finder eject) before unplug. Never yank mid-write.
+   - **Monthly Disk Utility First Aid** on each SSD.
+   - **Monthly CCC SafetyNet purge** when free space drops below 300 GB.
+   - **Post-power-loss check:** run First Aid after any unclean shutdown.
+2. Consider a launchd reminder for monthly First Aid.
+3. Document symptoms of exFAT corruption and recovery steps (restore from Cricket; if Cricket also corrupted, restore from NAS).
+
+**Exit criteria:** Hygiene section added to external-ssds.md. Recovery runbook exists.
+
+### Phase 10 — Post-M5 adjustments
+
+**Goal:** Take advantage of the 2 TB M5 Mac when it arrives.
+
+**Steps:**
+1. Revise "current year only on Mac" → "rolling 2-year window on Mac" (Mac becomes more authoritative, less archival pressure).
+2. Re-evaluate whether Carbonizer still needs to hold the full library, or can shrink to a rolling window too.
+3. Consider moving Lightroom Library off external and onto internal (performance win).
+4. Verify all phases above still work with the new disk topology.
+
+**Exit criteria:** Documented revision to authority rules in `device-schemas/macbook-personal.md` and `external-ssds.md`.
+
+---
+
+## Risks
+
+- **~~2024 Photos single-device risk — CONFIRMED ACUTE.~~** [RETRACTED 2026-04-22]. Per-subfolder du and find showed live content identical across Carbonizer and Cricket (233 GB, same month/file counts in RAW, JPG, DNG, Video). The 336 GB apparent gap was a `_CCC SafetyNet/` folder nested inside `Carbonizer/Photos/Photo Files/2024 Photos/` — orphans from Mac → Carbonizer task runs, which CCC correctly excludes from Carbonizer → Cricket replication. No acute risk; Cricket is a current live-content copy.
+- **SafetyNet nested inside active data path inflates totals.** `du`/Finder item counts of a folder that contains a `_CCC SafetyNet/` subfolder report a size that includes the SafetyNet content. When comparing two CCC-managed drives, compare LIVE CONTENT directly (measure per subfolder, exclude SafetyNet paths), not root totals.
+- **2025 Photos authority drift (38 GB).** Mac and Carbonizer disagree; need reconciliation in Phase 1 before automating CCC. If automation runs first, the drift could be erased in the wrong direction.
+- **exFAT corruption on unclean eject.** Residual risk; hygiene playbook (Phase 9) reduces but doesn't eliminate. Belt-and-suspenders via NAS + brother's UGREEN.
+- **Noisy Cricket loss in transit** during Phase 5 seed ship. Mitigation: insured shipping; or in-person delivery on next VT visit.
+- **Brother's NAS reliability** — his hardware is a single point of failure for offsite. Mitigation: Cricket stays at his house as cold DR (Phase 6 Option A).
+- **launchd job silent failure.** Mitigation: weekly health check (Phase 4) + CCC email on task failure (Phase 3).
+- **Tailscale connectivity** interruption between NAS pair. Mitigation: rsync resumes on next run; no partial-state loss.
+- **Mac disk pressure (69 GB free)** may force archival before gates are ready. Mitigation: Phase 2 reclaims nothing on Mac but Phase 4's continuous NAS backup enables safe early archival of 2024-only-on-Carbonizer content to NAS, reducing dependence on Mac-held working copies.
+
+## Open questions
+
+- [ ] **Project paths on Mac** — where do creative/project files live today? `~/workspace/` is code only; where are non-code projects? Answer drives Phase 8 scope.
+- [ ] **NAS path for projects** — new share, or reuse `Media/`? User preference.
+- [ ] **Brother's timeline** — when can he set up Tailscale on his DXP6800? Gates Phase 5 execution.
+- [ ] **Cricket ship method** — USPS Priority Mail Express with insurance, or in-person delivery? Affects Phase 5 seed sequencing.
+- [x] **CCC task inventory** (answered 2026-04-22): Four tasks wired — `2025 to Carbonizer` (Mac → Carbonizer, current year), `2026 to Carbonizer` (Mac → Carbonizer, current year), `Carbonizer backup` (Carbonizer → Noisy Cricket), `Carbonizer UGREEN Backup` (Carbonizer → NAS). Additive mode (not mirror). Cadence gap, not coverage gap. Phase 3 automates the cadence.
+- [ ] **launchd vs. cron vs. third-party scheduler** on Mac — user preference. launchd is macOS-native.
+- [ ] **Reconciliation of 2025 Photos drift** — if Carbonizer has 38 GB Mac doesn't, where did those files originate and should they go back to Mac?
+- [ ] **Music on Carbonizer (97 GB)** — in or out of scope? Currently not backed up elsewhere.
+
+## Sequencing
+
+```
+Phase 1 (baseline + drift)          ← start here; blocking for most downstream
+    ↓
+Phase 2 (reclaim 201 GB on SSDs)    ← independent; can run in parallel with P1
+    ↓
+Phase 3 (CCC automation)            ← depends on P1 reconciliation
+    ↓
+Phase 4 (continuous Mac → NAS)      ← depends on NAS Media share mounted (P1 step 5)
+    ↓
+Phase 8 (projects into P4 pipeline) ← merges into P4 scope; requires project paths decided
+    ↓
+Phase 5 (offsite to brother)        ← gated on brother's Tailscale setup
+    ↓
+Phase 6 (Cricket rotation policy)   ← after P5 seed lands
+    ↓
+Phase 7 (year-close gate)           ← requires P4 + P5 running for 2024 verification
+    ↓
+Phase 9 (exFAT hygiene)             ← can run in parallel, ongoing
+    ↓
+Phase 10 (post-M5 adjustments)      ← future; gated on hardware
+```
+
+## Status log
+
+- 2026-04-22 — Plan drafted. Device schema `device-schemas/external-ssds.md` created. Inventory baseline captured in this plan.
+- 2026-04-22 — Full 5-tier scan (Mac / Carbonizer / Cricket / NAS / [brother's pending]). Identified 313 GB of 2024 Photos existing only on Carbonizer. User triggered all CCC tasks; `Carbonizer backup` (→ Cricket) and `Carbonizer UGREEN Backup` (→ NAS) running. Closes single-device exposure onsite once complete. Offsite still pending Phase 5.
+- 2026-04-22 — NAS Media share mounted (`/Volumes/Media`, SMB). 10 TB used / 12 TB free. Existing photo archive: ~612 GB (2024 Photos 233 GB, Remote Year 93 GB, archive/ 187 GB, plus older trip folders). Typo drift: `Portalnd Trip` (should be `Portland`). NAS `backup` share exists but empty.
+- 2026-04-22 — Cricket anomalies captured: 195 GB `_CCC SafetyNet/` (vs Carbonizer's 1.2 GB), 192 GB `Media to Sort/` (not present on Carbonizer — investigate before touching). Cricket pre-run sizes: Photos 815 GB (vs Carbonizer 1.1 TB); 2024 Photos 233 GB (vs Carbonizer 546 GB) — Cricket and NAS matched pre-run, implying same lineage CCC snapshot.
+- 2026-04-22 — CCC log + Finder Get Info initially suggested Cricket stale: `Carbonizer Backup` task ran in 83 seconds; Finder showed Carbonizer 2024 Photos at 12,440 items / 586 GB vs Cricket at 5,542 items / 250 GB. Hypothesis was narrow CCC source scope.
+- 2026-04-22 — **RETRACTED.** Per-subfolder du + find confirmed Carbonizer and Cricket live 2024 Photos are identical (233 GB each, matching file counts per month folder: 2024-01 = 113, 2024-08 = 2017, 2024-12 = 280, etc.). The 336 GB gap was a nested `_CCC SafetyNet/` folder inside `Carbonizer/Photos/Photo Files/2024 Photos/` (313 GB of Mac-deletion orphans). CCC correctly excludes SafetyNet folders from source-to-destination replication, so Cricket correctly lacks this folder. The 83-second Carbonizer → Cricket run was correct no-op, not misconfiguration. CCC task config does NOT need to be recreated.
+- 2026-04-22 — `Carbonizer UGREEN Backup` writes to a separate NAS share `Carbonizer_BU` (not the `Media/photos/` measured earlier — two parallel NAS photo locations). `Carbonizer_BU` contents still need baseline measurement.
+- 2026-04-23 — `Carbonizer UGREEN Backup` run verified: 04/22 23:07:40 → 23:23:51 (16 min, exit 0). `Carbonizer_BU` 2024 Photos live content measured (via sudo over SMB) and matches Carbonizer 1:1: RAW 223G, JPG 9.8G, DNG empty, Video 407M. Three verified onsite copies of 2024 Photos live content (Carbonizer + Cricket + `Carbonizer_BU`); `Media/photos/2024 Photos/` holds a fourth independent copy from a prior non-CCC process. Onsite redundancy is solid; offsite still pending Phase 5.

--- a/environment/shell-setup.md
+++ b/environment/shell-setup.md
@@ -1,0 +1,59 @@
+# Shell + Terminal Setup (new workstation)
+
+Bring a new macOS workstation to parity with the reference shell / terminal setup: Powerlevel10k on zsh, Ghostty with MesloLGS Nerd Font, two-line rainbow prompt with unique-prefix path truncation.
+
+Config lives as snapshots under `~/Atlas/config/`; this doc is the restore direction (Atlas → `$HOME`).
+
+## Prerequisites
+
+- Homebrew installed
+- `~/Atlas/` mounted (Google Drive for Desktop running and synced)
+- Ghostty installed (from [ghostty.org](https://ghostty.org) — not reliably brew-cask-available)
+
+## Steps
+
+```sh
+# 1. Theme + font
+brew install powerlevel10k
+brew install --cask font-meslo-lg-nerd-font
+
+# 2. Restore shell config from Atlas
+cp ~/Atlas/config/shell/zshrc ~/.zshrc
+cp ~/Atlas/config/shell/p10k.zsh ~/.p10k.zsh
+
+# 3. Restore terminal config from Atlas
+mkdir -p ~/.config/ghostty
+cp ~/Atlas/config/terminal/ghostty-config ~/.config/ghostty/config
+
+# 4. Reload
+exec zsh
+```
+
+## Verification
+
+- Open a new Ghostty window (Cmd+Q then relaunch the first time, so font is picked up).
+- Prompt renders in two lines, rainbow segments, with `andrewlee@<host>` visually distinct from the command.
+- Path truncates as `~/w/p/life-atlas`-style (unique-prefix).
+- `echo $''` shows a GitHub glyph, not a tofu rectangle — confirms the Nerd Font loaded.
+
+## Ongoing sync
+
+After editing any tracked dotfile on a workstation, snapshot forward into Atlas:
+
+```sh
+./environment/sync-shell-config.sh
+```
+
+To check drift without writing:
+
+```sh
+./environment/sync-shell-config.sh --check
+```
+
+The script is one-way (`$HOME` → Atlas). The restore direction above is manual by design — moving snapshots onto a new machine is a deliberate, first-time-only operation.
+
+## Notes
+
+- Do not symlink. Atlas lives on a cloud-sync daemon; shell startup should not depend on it.
+- If `~/.zshrc` already has user-specific content on the target machine, merge by hand — the snapshot is a known-good baseline, not an overwrite.
+- Non-macOS workstations need their own adaptation — the snapshots assume macOS paths (`/opt/homebrew/share/powerlevel10k/...`).

--- a/environment/sync-shell-config.sh
+++ b/environment/sync-shell-config.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# sync-shell-config.sh — snapshot live shell / terminal dotfiles into Atlas.
+#
+# One-way: $HOME → ~/Atlas/config/{shell,terminal}/
+# Run after editing any of the tracked dotfiles.
+#
+# Usage:
+#   ./environment/sync-shell-config.sh          Copy forward (source of truth = $HOME).
+#   ./environment/sync-shell-config.sh --check  Report drift only; exit 1 if any file differs.
+
+set -euo pipefail
+
+ATLAS_SHELL="$HOME/Atlas/config/shell"
+ATLAS_TERMINAL="$HOME/Atlas/config/terminal"
+
+# src|dest pairs. $HOME is the source of truth.
+PAIRS=(
+  "$HOME/.zshrc|$ATLAS_SHELL/zshrc"
+  "$HOME/.p10k.zsh|$ATLAS_SHELL/p10k.zsh"
+  "$HOME/.config/ghostty/config|$ATLAS_TERMINAL/ghostty-config"
+)
+
+CHECK_ONLY=0
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=1
+elif [[ -n "${1:-}" ]]; then
+  echo "unknown arg: $1" >&2
+  echo "usage: $0 [--check]" >&2
+  exit 2
+fi
+
+mkdir -p "$ATLAS_SHELL" "$ATLAS_TERMINAL"
+
+drift=0
+for pair in "${PAIRS[@]}"; do
+  src="${pair%%|*}"
+  dest="${pair##*|}"
+
+  if [[ ! -f "$src" ]]; then
+    echo "  missing source: $src (skipping)"
+    continue
+  fi
+
+  if [[ -f "$dest" ]] && cmp -s "$src" "$dest"; then
+    echo "  up to date: $dest"
+    continue
+  fi
+
+  drift=1
+  if (( CHECK_ONLY )); then
+    if [[ -f "$dest" ]]; then
+      echo "  DRIFT: $src differs from $dest"
+    else
+      echo "  DRIFT: $dest does not exist yet"
+    fi
+  else
+    cp "$src" "$dest"
+    echo "  copied: $src → $dest"
+  fi
+done
+
+if (( CHECK_ONLY )) && (( drift )); then
+  echo "drift detected — run without --check to sync"
+  exit 1
+fi
+
+echo "done."

--- a/folder-schemas/config.md
+++ b/folder-schemas/config.md
@@ -1,0 +1,46 @@
+# ⚙️ Config — Folder Schema
+
+`~/Atlas/config/` holds cross-device configuration — the settings, themes, shortcuts, and dotfile snapshots that make a new workstation feel like a known one.
+
+**Config is snapshot-synced, not live.** Most entries are either (a) read-at-setup-time material (themes, desktop images) or (b) periodic snapshots of live state that lives under `$HOME`. Dotfiles in particular are copied, not symlinked — cloud sync daemons should not sit in the critical path of a shell starting up.
+
+---
+
+## 📂 Subfolders
+
+| Subfolder | Contents | Sync model |
+|---|---|---|
+| `ai/` | Prompts, persona files, model configs | Snapshot / manual |
+| `apps/` | App-specific exports (settings bundles, preference plists) | Snapshot / manual |
+| `desktop-images/` | Wallpapers set across devices | Read-at-setup |
+| `keys/` | SSH keys, GPG keys, recovery material | **Never** accessed by automation |
+| `settings/` | OS-level settings exports | Snapshot |
+| `shell/` | Shell dotfile snapshots (`zshrc`, `p10k.zsh`) | Periodic snapshot via `environment/sync-shell-config.sh` |
+| `shortcuts/` | Keyboard / app shortcut definitions | Snapshot |
+| `templates/` | Reusable document / project templates | Read-at-setup |
+| `terminal/` | Terminal emulator config snapshots (e.g., `ghostty-config`) | Periodic snapshot via `environment/sync-shell-config.sh` |
+| `themes/` | Editor / terminal color themes | Read-at-setup |
+
+---
+
+## 🔁 Shell + Terminal Snapshots
+
+Live dotfiles stay in their canonical `$HOME` paths. Atlas holds copies, refreshed by running `environment/sync-shell-config.sh` after edits.
+
+| Live path | Atlas snapshot |
+|---|---|
+| `~/.zshrc` | `~/Atlas/config/shell/zshrc` |
+| `~/.p10k.zsh` | `~/Atlas/config/shell/p10k.zsh` |
+| `~/.config/ghostty/config` | `~/Atlas/config/terminal/ghostty-config` |
+
+Direction is one-way: `$HOME` is the source of truth. The sync script copies forward and refuses to clobber anything else. To verify drift without writing: `./environment/sync-shell-config.sh --check`.
+
+New-machine setup flows the other direction — see [`environment/shell-setup.md`](../environment/shell-setup.md).
+
+---
+
+## 🚫 Anti-patterns
+
+- Do not symlink live dotfiles into `~/Atlas/` subfolders. Cloud sync shouldn't sit on a shell's startup path.
+- Do not edit snapshots in `~/Atlas/config/shell/` or `~/Atlas/config/terminal/` directly — the next sync will overwrite them. Edit under `$HOME` and run the sync script.
+- Do not put secrets anywhere except `keys/`, and never let automation read `keys/`.

--- a/tools/immich-dedup/.env.example
+++ b/tools/immich-dedup/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and fill in your own values. `.env` is gitignored.
+
+# Base URL of your Immich instance. Do NOT include a trailing /api — the tool appends that.
+IMMICH_URL=http://your-immich-host:2283
+
+# An API key with at least `duplicate.read` permission.
+# Generate one in Immich: Account settings → API Keys → New API Key.
+IMMICH_API_KEY=

--- a/tools/immich-dedup/.gitignore
+++ b/tools/immich-dedup/.gitignore
@@ -1,0 +1,8 @@
+.env
+__pycache__/
+*.pyc
+*.pyo
+report.md
+groups.json
+gallery.html
+apply.log.jsonl

--- a/tools/immich-dedup/LICENSE
+++ b/tools/immich-dedup/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andrew Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/immich-dedup/README.md
+++ b/tools/immich-dedup/README.md
@@ -1,0 +1,131 @@
+# immich-dedup
+
+A read-only classifier for Immich's duplicate detection output. It takes the raw list of duplicate groups Immich surfaces, sorts them into handling-appropriate buckets, and prints a markdown report.
+
+The problem it solves: Immich's duplicate finder does a good job identifying duplicates but gives you one flat list to review. For a library with tens of thousands of duplicate assets, that list is unreviewable one-at-a-time. This tool splits the list into buckets where the right action is obvious (bit-identical, HEIC+JPEG pairs, bursts) and a smaller pile that genuinely needs human attention.
+
+**This tool writes nothing to Immich.** It's a reporting layer only — intended as the first step before any destructive action.
+
+## Status
+
+Early. Currently produces a markdown report; does not drive any Immich state change. The intent is to grow into a fuller triage tool (possibly with a lightweight web UI for the remaining edge cases), but the first pass is deliberately narrow.
+
+## Requirements
+
+- Python 3.9+ (no third-party dependencies — standard library only)
+- An Immich instance you can reach over HTTP
+- An Immich API key with permission to read duplicates (`duplicate.read`)
+
+## Install
+
+Clone / copy the directory. There's nothing to install.
+
+```sh
+cd tools/immich-dedup
+cp .env.example .env
+# edit .env with your Immich URL and API key
+```
+
+## Workflow
+
+The three scripts are designed to be used in order:
+
+1. **`classify.py`** — fast bucket breakdown. Read the report, decide which buckets look interesting.
+2. **`gallery.py`** — visual review. Open the HTML, scroll through samples per bucket, build confidence in the classification before trusting it at scale.
+3. **`apply.py`** — execution. Per-bucket, dry-run by default, writes to Immich's trash (soft-delete, 30-day recovery).
+
+```sh
+# 1. Report (markdown)
+python3 classify.py > report.md
+
+# 2. Visual review (open in browser)
+python3 gallery.py
+open gallery.html
+
+# 3. Dry-run (no writes)
+python3 apply.py --bucket heic_jpeg_pair
+
+# 3. Actually apply (writes to Immich trash)
+python3 apply.py --bucket heic_jpeg_pair --confirm
+```
+
+### Optional flags
+
+```sh
+# classify.py
+python3 classify.py --out report.md          # write to file instead of stdout
+python3 classify.py --raw groups.json        # also dump the raw API response
+
+# gallery.py
+python3 gallery.py --samples 50              # 50 random groups per bucket (default: 20)
+python3 gallery.py --size preview            # larger thumbnails (slower to fetch)
+python3 gallery.py --seed 123                # different random sample
+
+# apply.py
+python3 apply.py --tier high                 # all buckets in the high-confidence tier
+python3 apply.py --bucket a,b,c              # comma-separated buckets also work
+python3 apply.py --bucket burst --limit 10   # canary: process at most 10 groups
+python3 apply.py --bucket foo --confirm      # execute
+python3 apply.py --bucket foo --confirm --yes  # skip the interactive prompt
+```
+
+### Safety posture of `apply.py`
+
+- Dry-run by default. `--confirm` is required to write.
+- Interactive "continue?" prompt when `--confirm` is used in a TTY. Bypass with `--yes`.
+- Soft-delete only. Items land in Immich's trash with 30-day recovery; there is no hard-delete path in this tool.
+- Every resolved group appended to `apply.log.jsonl` with the bucket, keeper ids, trashed ids, batch number, and the API response status. Errors are logged without aborting the remaining batches.
+- Groups with no `suggestedKeepAssetIds` are skipped — the tool refuses to guess.
+
+## Output
+
+A markdown report with:
+
+- Totals: number of duplicate groups, total assets across them, estimated reclaim in GB if Immich's `suggestedKeepAssetIds` is respected.
+- **Bucket breakdown table** — counts and reclaim-in-GB per bucket.
+- **Samples** — the first 3 groups from each bucket, so the bucket labels are legible and spot-checkable.
+
+## Buckets
+
+Buckets are tagged with a confidence tier so the report can group safe-to-bulk-accept groups separately from the ones that need a human. Ordering matters in the classifier: more-specific rules fire first, and `dominant_keeper` is a confidence-based catch-all that scoops up groups where Immich's suggestion is clearly correct on size/pixel asymmetry alone.
+
+| Bucket | Confidence | Meaning | Typical handling |
+|---|---|---|---|
+| `heic_jpeg_pair` | high | Same image stored as both HEIC and JPEG (Live Photo exports, share-sheet derivatives). | Keeper: HEIC original. Bulk-accept. |
+| `rendition_set` | high | One source photo plus its iOS Photos resolution renditions (`_1_105_c`, `_4_5005_c`), possibly with a same-photo-different-name copy. Detected via shared canonical filename stem. | Keeper: full-resolution original. Bulk-accept. |
+| `dominant_keeper` | high | Catch-all: suggested keeper is ≥2× the nearest competitor (size or pixels), or holds the majority of bytes in the group. | Bulk-accept. |
+| `burst` | medium | Same device, captures within 5 seconds. | Immich's size-based pick is usually right; sample-review ~5%. |
+| `screenshots` | medium | PNG with no camera EXIF, filename like `Screenshot_*` or `IMG_*.PNG`. | Low-stakes bulk-accept. |
+| `live_photo_pair` | review | Still image paired with a motion video via `livePhotoVideoId`. | Usually not a true duplicate — consider stacking instead of deleting. |
+| `edge_case` | review | None of the above — cross-format, mixed dimensions, mixed favorites, etc. | Human review, one-by-one. |
+
+Classification is conservative: anything that doesn't match a confident rule falls into `edge_case`. Better to over-flag than under-flag.
+
+## Configuration
+
+```env
+# .env
+IMMICH_URL=http://your-immich-host:2283
+IMMICH_API_KEY=your-api-key-here
+```
+
+Get an API key from Immich: **Account settings → API Keys → New API Key**. The only permission needed for this tool is `duplicate.read`.
+
+The URL should be the base URL of your Immich instance — do *not* include `/api`. The tool appends that itself.
+
+## Roadmap
+
+- `classify.py` — report only (v0, current)
+- `apply.py` — apply Immich's suggestions to the safe buckets via `POST /api/duplicates/resolve`, with a required `--confirm` flag and dry-run default
+- Lightweight web UI for reviewing the `edge_case` bucket 10 groups at a time instead of one
+- Additional signals that Immich's built-in detection misses (e.g., near-duplicates that survived Immich's thresholds)
+
+The v0 report is enough to decide whether subsequent phases are worth building. If the `bit_identical` + `heic_jpeg_pair` + `screenshots` buckets together cover ≳80% of your groups, Immich's built-in "Duplicate all" with a spot-check is probably sufficient — no further tooling needed.
+
+## License
+
+MIT. See [LICENSE](LICENSE).
+
+## Contributing / feedback
+
+This is incubating inside a larger personal-automation repo and will likely extract to its own repository once it stabilizes. In the meantime, issues and suggestions are welcome wherever this ends up hosted.

--- a/tools/immich-dedup/apply.py
+++ b/tools/immich-dedup/apply.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+immich-dedup apply: execute bucket-filtered duplicate resolution.
+
+Works in tandem with classify.py. Fetches the current duplicate list from
+Immich, filters to the buckets you specify, and calls Immich's
+/api/duplicates/resolve endpoint to move the non-keeper assets to the trash.
+
+Safety posture:
+    - Dry-run by default. No writes until you pass --confirm.
+    - Interactive confirmation prompt when --confirm is used in a TTY.
+    - Soft-delete only. Items land in Immich's trash with 30-day recovery.
+    - Every action is appended to a JSONL log, one entry per group.
+    - Errors in a batch are logged and the run continues; they don't abort
+      the remaining batches, so partial failures don't leave the library
+      in a half-processed state.
+
+Usage:
+    python3 apply.py --bucket heic_jpeg_pair              # dry-run, 8 groups
+    python3 apply.py --bucket heic_jpeg_pair --confirm    # actually apply
+    python3 apply.py --tier high --limit 10 --confirm     # canary: 10 groups
+    python3 apply.py --tier high --confirm                # full run, high-tier only
+    python3 apply.py --bucket rendition_set,dominant_keeper --confirm
+
+No third-party Python dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timezone
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import classify  # noqa: E402
+
+
+DEFAULT_BATCH_SIZE = 50
+DEFAULT_LOG_PATH = "apply.log.jsonl"
+DEFAULT_HTTP_TIMEOUT = 300.0   # /duplicates/resolve does meaningful DB work
+DEFAULT_RETRIES = 3            # for transient socket timeouts / connection resets
+
+
+# Exceptions that indicate a transient network/server issue worth retrying
+# (and then, if retries exhaust, worth logging-and-continuing rather than
+# aborting the whole run). OSError is the important one here — socket.timeout
+# inherits from it in Python 3.9+, and ConnectionError / BrokenPipeError
+# also subclass it.
+TRANSIENT_EXCEPTIONS = (
+    urllib.error.URLError,
+    urllib.error.HTTPError,
+    OSError,
+    json.JSONDecodeError,
+)
+
+
+# -------- group selection (pure, testable) --------
+
+def select_groups(
+    groups: list[dict],
+    bucket_filter: set[str] | None = None,
+    limit: int | None = None,
+) -> list[tuple[str, dict]]:
+    """Pick groups to resolve. Returns list of (bucket_label, resolve_dto).
+
+    A group is selected iff:
+      - its classified bucket is in `bucket_filter` (if provided), and
+      - it has ≥1 suggested keeper asset id (we refuse to guess), and
+      - there is ≥1 non-keeper asset to trash.
+
+    The resolve_dto is shaped for the `/api/duplicates/resolve` endpoint:
+        {duplicateId, keepAssetIds, trashAssetIds}
+    """
+    out: list[tuple[str, dict]] = []
+    for g in groups:
+        b = classify.classify(g)
+        if bucket_filter is not None and b not in bucket_filter:
+            continue
+        keep_ids = list(g.get("suggestedKeepAssetIds") or [])
+        if not keep_ids:
+            continue
+        keep_set = set(keep_ids)
+        all_ids = [a.get("id") for a in (g.get("assets") or []) if a.get("id")]
+        trash_ids = [aid for aid in all_ids if aid not in keep_set]
+        if not trash_ids:
+            continue
+        out.append((b, {
+            "duplicateId": g.get("duplicateId"),
+            "keepAssetIds": keep_ids,
+            "trashAssetIds": trash_ids,
+        }))
+        if limit is not None and len(out) >= limit:
+            break
+    return out
+
+
+def expand_bucket_filter(
+    bucket_args: list[str] | None,
+    tier_arg: str | None,
+) -> set[str]:
+    """Merge --bucket and --tier arguments into a normalized set of bucket names."""
+    result: set[str] = set()
+    if bucket_args:
+        for item in bucket_args:
+            for name in item.split(","):
+                name = name.strip()
+                if name:
+                    result.add(name)
+    if tier_arg:
+        for b, t in classify.BUCKET_CONFIDENCE.items():
+            if t == tier_arg:
+                result.add(b)
+    return result
+
+
+# -------- Immich API --------
+
+def post_resolve_batch(base_url: str, api_key: str,
+                       batch: list[dict],
+                       timeout: float = DEFAULT_HTTP_TIMEOUT,
+                       retries: int = DEFAULT_RETRIES) -> list[dict]:
+    """POST /duplicates/resolve with retry on transient failures.
+
+    Retries on any TRANSIENT_EXCEPTIONS with exponential backoff (1s, 2s, 4s).
+    Re-raises the last error after the final attempt so the caller can log it.
+    """
+    body = json.dumps({"groups": batch}).encode()
+    last_err: Exception | None = None
+    for attempt in range(retries):
+        req = urllib.request.Request(
+            f"{base_url.rstrip('/')}/api/duplicates/resolve",
+            data=body,
+            headers={
+                "x-api-key": api_key,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read())
+        except TRANSIENT_EXCEPTIONS as e:
+            last_err = e
+            if attempt < retries - 1:
+                wait = 2 ** attempt  # 1s, 2s, 4s
+                print(
+                    f"    attempt {attempt + 1}/{retries} failed "
+                    f"({type(e).__name__}: {e}); retrying in {wait}s…",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+    # All retries exhausted — re-raise so the caller logs it and moves on.
+    assert last_err is not None
+    raise last_err
+
+
+# -------- main --------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply Immich duplicate resolution per bucket. "
+                    "Soft-delete only (items go to Immich trash, 30-day recovery).",
+    )
+    parser.add_argument("--env", default=".env",
+                        help="Path to .env file (default: ./.env).")
+    parser.add_argument(
+        "--bucket", action="append", default=None,
+        help="Bucket to include. Repeatable; comma-separated also accepted.",
+    )
+    parser.add_argument(
+        "--tier", choices=["high", "medium", "review"], default=None,
+        help="Include all buckets in a confidence tier.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Cap on groups to process (use for canary runs).",
+    )
+    parser.add_argument(
+        "--confirm", action="store_true",
+        help="Actually execute. Without this flag, this is a dry-run.",
+    )
+    parser.add_argument(
+        "--yes", action="store_true",
+        help="Skip the interactive prompt when --confirm is used in a TTY.",
+    )
+    parser.add_argument(
+        "--log", default=DEFAULT_LOG_PATH,
+        help=f"Append JSONL log of actions (default: {DEFAULT_LOG_PATH}).",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=DEFAULT_BATCH_SIZE,
+        help=f"Groups per API call (default: {DEFAULT_BATCH_SIZE}).",
+    )
+    args = parser.parse_args(argv)
+
+    # Bucket / tier filter.
+    buckets = expand_bucket_filter(args.bucket, args.tier)
+    if not buckets:
+        print("error: must specify at least one --bucket or --tier",
+              file=sys.stderr)
+        return 2
+    unknown = buckets - set(classify.BUCKETS)
+    if unknown:
+        print(f"error: unknown bucket(s): {', '.join(sorted(unknown))}",
+              file=sys.stderr)
+        print(f"valid buckets: {', '.join(classify.BUCKETS)}", file=sys.stderr)
+        return 2
+
+    # Env.
+    classify.load_env(args.env)
+    base_url = os.environ.get("IMMICH_URL")
+    api_key = os.environ.get("IMMICH_API_KEY")
+    if not base_url or not api_key:
+        print("error: IMMICH_URL and IMMICH_API_KEY must be set",
+              file=sys.stderr)
+        return 2
+
+    print("[apply] fetching duplicates…", file=sys.stderr)
+    groups = classify.fetch_duplicates(base_url, api_key)
+
+    selected = select_groups(groups, bucket_filter=buckets, limit=args.limit)
+    total_groups = len(selected)
+    total_trash = sum(len(dto["trashAssetIds"]) for _, dto in selected)
+
+    mode = "APPLY" if args.confirm else "DRY-RUN"
+    print(
+        f"[{mode}] {total_groups} groups selected · {total_trash} assets to trash · "
+        f"buckets: {', '.join(sorted(buckets))}"
+        + (f" · limit {args.limit}" if args.limit else ""),
+        file=sys.stderr,
+    )
+
+    # Dry-run preview.
+    if not args.confirm:
+        by_bucket = defaultdict(int)
+        for b, _ in selected:
+            by_bucket[b] += 1
+        for b in classify.BUCKETS:
+            if b in by_bucket:
+                print(f"    {b:20s} {by_bucket[b]:,} groups", file=sys.stderr)
+        if total_groups:
+            preview = selected[: min(5, total_groups)]
+            print("\n[dry-run] first 5 (of this run):", file=sys.stderr)
+            for b, dto in preview:
+                print(
+                    f"    {b:20s} group {dto['duplicateId']} · "
+                    f"keep {len(dto['keepAssetIds'])} · "
+                    f"trash {len(dto['trashAssetIds'])}",
+                    file=sys.stderr,
+                )
+        print("\n[dry-run] no changes made. Re-run with --confirm to write.",
+              file=sys.stderr)
+        return 0
+
+    # Interactive confirmation (TTY only, skippable with --yes).
+    if sys.stdin.isatty() and not args.yes:
+        print(
+            f"\n*** About to trash {total_trash} assets across "
+            f"{total_groups} groups. ***\n"
+            f"*** Soft-delete → Immich trash (30-day recovery). ***\n"
+            f"*** Buckets: {', '.join(sorted(buckets))}. ***\n"
+            f"*** Log: {args.log} ***\n"
+            f"Continue? [y/N]: ",
+            end="", file=sys.stderr, flush=True,
+        )
+        response = input().strip().lower()
+        if response != "y":
+            print("[abort] user cancelled", file=sys.stderr)
+            return 1
+
+    # Execute.
+    log_file = open(args.log, "a")
+    trashed = 0
+    errored = 0
+    try:
+        for i in range(0, total_groups, args.batch_size):
+            window = selected[i : i + args.batch_size]
+            batch_num = i // args.batch_size + 1
+            total_batches = (total_groups + args.batch_size - 1) // args.batch_size
+            print(
+                f"[APPLY] batch {batch_num}/{total_batches} "
+                f"({len(window)} groups)…",
+                file=sys.stderr,
+            )
+            payload = [dto for _, dto in window]
+            ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            try:
+                resp = post_resolve_batch(base_url, api_key, payload)
+                for b, dto in window:
+                    log_file.write(json.dumps({
+                        "ts": ts,
+                        "bucket": b,
+                        "duplicateId": dto["duplicateId"],
+                        "keepAssetIds": dto["keepAssetIds"],
+                        "trashAssetIds": dto["trashAssetIds"],
+                        "batch": batch_num,
+                        "response_ok": True,
+                    }) + "\n")
+                    trashed += len(dto["trashAssetIds"])
+                log_file.flush()
+            except TRANSIENT_EXCEPTIONS as e:
+                errored += sum(len(dto["trashAssetIds"]) for _, dto in window)
+                log_file.write(json.dumps({
+                    "ts": ts,
+                    "batch": batch_num,
+                    "error": f"{type(e).__name__}: {e}",
+                    "group_ids": [dto["duplicateId"] for _, dto in window],
+                }) + "\n")
+                log_file.flush()
+                print(
+                    f"    ! batch {batch_num} failed after retries "
+                    f"({type(e).__name__}: {e}); continuing",
+                    file=sys.stderr,
+                )
+    finally:
+        log_file.close()
+
+    print(
+        f"[APPLY] done · trashed {trashed} assets · "
+        f"{errored} errors · log: {args.log}",
+        file=sys.stderr,
+    )
+    return 0 if errored == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/immich-dedup/classify.py
+++ b/tools/immich-dedup/classify.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""
+immich-dedup: classify Immich duplicate groups into actionable buckets.
+
+Fetches duplicate groups from an Immich instance, categorizes them by the
+kind of duplicate they are (bit-identical, HEIC/JPEG pair, burst, screenshot,
+Live Photo pair, or edge case), and prints a markdown report. Writes nothing
+back to Immich.
+
+The goal is to turn "24,000 duplicates to review" into "18,000 duplicates of
+a type that can be bulk-handled + 2,000 real edge cases worth human attention."
+
+Usage:
+    cp .env.example .env   # fill in IMMICH_URL and IMMICH_API_KEY
+    python3 classify.py > report.md
+
+No third-party Python dependencies. Standard library only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+
+
+# Ordering matters: most-specific / highest-confidence buckets fire first.
+BUCKETS = [
+    "heic_jpeg_pair",
+    "live_photo_pair",
+    "rendition_set",
+    "burst",
+    "screenshots",
+    "dominant_keeper",
+    "edge_case",
+]
+
+# How much human oversight each bucket warrants. The report groups by tier.
+#   high   → safe to bulk-accept Immich's suggestion
+#   medium → bulk-accept with a 5% sample check
+#   review → per-group human judgment
+BUCKET_CONFIDENCE = {
+    "heic_jpeg_pair": "high",
+    "rendition_set": "high",
+    "dominant_keeper": "high",
+    "burst": "medium",
+    "screenshots": "medium",
+    "live_photo_pair": "review",
+    "edge_case": "review",
+}
+
+CONFIDENCE_TIERS = [
+    ("high", "High confidence — safe to bulk-accept Immich's suggestion"),
+    ("medium", "Medium confidence — bulk-accept with a 5% sample check"),
+    ("review", "Needs review"),
+]
+
+# Regexes used for canonical-stem matching in rendition_set detection.
+# Matches iOS Photos rendition suffixes and macOS Finder copy suffixes.
+#
+# iOS Photos writes several rendition variants per asset, distinguished by a
+# trailing letter code:
+#   _c = compressed / reduced-size delivery rendition
+#   _o = original-format rendition
+#   _a = adjusted (edited) rendition
+# All appear as `_<n>_<nnn>_[aco]` or `_<nnnn>_[aco]` at the end of the filename.
+_EXT_RE = re.compile(r"\.[A-Za-z0-9]{2,5}$")
+_RENDITION_SUFFIX_RE = re.compile(r"_\d+(_\d+)?_[aco]$")
+_COPY_SUFFIX_RE = re.compile(r" \(\d+\)$")
+
+
+# --- env loading ---
+
+def load_env(path: str = ".env") -> None:
+    if not os.path.isfile(path):
+        return
+    with open(path) as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            os.environ.setdefault(
+                key.strip(), val.strip().strip('"').strip("'")
+            )
+
+
+# --- Immich API ---
+
+def fetch_duplicates(base_url: str, api_key: str) -> list[dict]:
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/duplicates",
+        headers={"x-api-key": api_key, "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.load(resp)
+
+
+# --- classification ---
+
+def classify(group: dict) -> str:
+    """Return the bucket label for a duplicate group.
+
+    Ordering: most-specific rules fire first. Groups that don't match a
+    specific pattern fall through to `dominant_keeper` (a confidence-based
+    catch-all for when Immich's suggested keeper is clearly correct by size
+    / pixel asymmetry), or finally `edge_case`.
+    """
+    assets = group.get("assets") or []
+    if len(assets) < 2:
+        return "edge_case"
+
+    if is_heic_jpeg_pair(assets):
+        return "heic_jpeg_pair"
+    if is_live_photo_pair(assets):
+        return "live_photo_pair"
+    if is_rendition_set(assets):
+        return "rendition_set"
+    if is_burst(assets):
+        return "burst"
+    if is_screenshots(assets):
+        return "screenshots"
+    if is_dominant_keeper(group):
+        return "dominant_keeper"
+    return "edge_case"
+
+
+def is_heic_jpeg_pair(assets: list[dict]) -> bool:
+    mimes = [a.get("originalMimeType") or "" for a in assets]
+    allowed = {"image/heic", "image/heif", "image/jpeg"}
+    if not all(m in allowed for m in mimes):
+        return False
+    has_heic = any(m in ("image/heic", "image/heif") for m in mimes)
+    has_jpeg = any(m == "image/jpeg" for m in mimes)
+    return has_heic and has_jpeg
+
+
+def is_live_photo_pair(assets: list[dict]) -> bool:
+    # Live Photo = still image + short motion video paired via livePhotoVideoId.
+    types = sorted(a.get("type") for a in assets)
+    if types != ["IMAGE", "VIDEO"]:
+        return False
+    ids = {a.get("id") for a in assets}
+    return any(a.get("livePhotoVideoId") in ids for a in assets)
+
+
+def is_screenshots(assets: list[dict]) -> bool:
+    return all(_is_screenshot_asset(a) for a in assets)
+
+
+def _is_screenshot_asset(asset: dict) -> bool:
+    exif = asset.get("exifInfo") or {}
+    if exif.get("make"):
+        return False
+    name = (asset.get("originalFileName") or "").lower()
+    mime = asset.get("originalMimeType") or ""
+    if mime != "image/png":
+        return False
+    return name.startswith("screenshot") or name.startswith("img_")
+
+
+def is_burst(assets: list[dict], span_seconds: float = 5.0) -> bool:
+    # Same device + all captures within a short time window.
+    devices = {
+        ((a.get("exifInfo") or {}).get("make"),
+         (a.get("exifInfo") or {}).get("model"))
+        for a in assets
+    }
+    if len(devices) != 1:
+        return False
+    device = next(iter(devices))
+    if device == (None, None):
+        return False
+
+    times = []
+    for a in assets:
+        ts = a.get("fileCreatedAt")
+        if not ts:
+            return False
+        try:
+            times.append(datetime.fromisoformat(ts.replace("Z", "+00:00")))
+        except ValueError:
+            return False
+    span = (max(times) - min(times)).total_seconds()
+    return span <= span_seconds
+
+
+def canonical_stem(filename: str) -> str:
+    """Strip extension + iOS rendition suffix + macOS copy suffix for comparison.
+
+    Examples:
+        "ADD78468-...710D.jpeg"              → "add78468-...710d"
+        "ADD78468-...710D_1_105_c.jpeg"      → "add78468-...710d"
+        "ADD78468-...710D_4_5005_c.jpeg"     → "add78468-...710d"
+        "IMG_1014 (2).PNG"                   → "img_1014"
+        "IMG_5371.PNG"                       → "img_5371"
+    """
+    stem = _EXT_RE.sub("", filename or "")
+    stem = _RENDITION_SUFFIX_RE.sub("", stem)
+    stem = _COPY_SUFFIX_RE.sub("", stem)
+    return stem.lower()
+
+
+def is_rendition_set(assets: list[dict]) -> bool:
+    """True if ≥2 assets in the group share a canonical stem.
+
+    Catches the common iOS Photos pattern: one original plus its
+    auto-generated resolution renditions (_1_105_c, _4_5005_c, etc.),
+    optionally mixed with a same-photo-different-name copy.
+    """
+    stems = [canonical_stem(a.get("originalFileName") or "") for a in assets]
+    stems = [s for s in stems if s]
+    if not stems:
+        return False
+    counts = Counter(stems)
+    top_stem, top_count = counts.most_common(1)[0]
+    return top_count >= 2
+
+
+def is_dominant_keeper(group: dict) -> bool:
+    """True when Immich's suggested keeper is clearly correct by size/pixel asymmetry.
+
+    A confidence-based catch-all for groups that don't match a more specific
+    pattern. Fires if *any* of:
+      - keeper's file size ≥ sum of all losers' sizes (keeper holds majority of bytes)
+      - keeper's pixel count ≥ 2× the largest loser's pixel count
+      - keeper's file size ≥ 2× the largest loser's file size
+    """
+    keep_ids = set(group.get("suggestedKeepAssetIds") or [])
+    assets = group.get("assets") or []
+    if not keep_ids:
+        return False
+    keepers = [a for a in assets if a.get("id") in keep_ids]
+    losers = [a for a in assets if a.get("id") not in keep_ids]
+    if not keepers or not losers:
+        return False
+
+    keeper = keepers[0]
+    keeper_size = asset_size(keeper)
+    keeper_pixels = (keeper.get("width") or 0) * (keeper.get("height") or 0)
+
+    loser_sizes = [asset_size(a) for a in losers]
+    loser_pixels = [(a.get("width") or 0) * (a.get("height") or 0) for a in losers]
+    max_loser_size = max(loser_sizes) if loser_sizes else 0
+    max_loser_pixels = max(loser_pixels) if loser_pixels else 0
+    total_loser_size = sum(loser_sizes)
+
+    if keeper_size > 0 and keeper_size >= total_loser_size:
+        return True
+    if keeper_pixels > 0 and keeper_pixels >= 2 * max_loser_pixels:
+        return True
+    if max_loser_size > 0 and keeper_size >= 2 * max_loser_size:
+        return True
+    return False
+
+
+# --- reclaim estimate ---
+
+def asset_size(asset: dict) -> int:
+    return (asset.get("exifInfo") or {}).get("fileSizeInByte") or 0
+
+
+def reclaim_bytes(group: dict) -> int:
+    """Bytes freed if Immich's `suggestedKeepAssetIds` is respected.
+
+    Falls back to keeping the single largest asset when Immich has no
+    suggestion for the group.
+    """
+    assets = group.get("assets") or []
+    keep_ids = set(group.get("suggestedKeepAssetIds") or [])
+    if keep_ids:
+        losers = [a for a in assets if a.get("id") not in keep_ids]
+    else:
+        ordered = sorted(assets, key=asset_size, reverse=True)
+        losers = ordered[1:]
+    return sum(asset_size(a) for a in losers)
+
+
+# --- reporting ---
+
+BUCKET_DESCRIPTIONS = {
+    "heic_jpeg_pair": "Same image stored as both HEIC and JPEG (Live Photo exports, share-sheet derivatives). Typical keeper: HEIC original.",
+    "rendition_set": "One source photo plus its iOS Photos resolution renditions (`_1_105_c`, `_4_5005_c`, etc.). Immich's size-based suggestion picks the full-resolution original.",
+    "dominant_keeper": "Immich's suggested keeper is overwhelmingly correct by size/pixel asymmetry (≥2× the nearest competitor, or majority of total bytes).",
+    "burst": "Same device, captures within 5 seconds. Immich's size-based suggestion is usually right.",
+    "screenshots": "PNG with no camera EXIF, filename like `Screenshot_*` or `IMG_*.PNG`. Low-stakes.",
+    "live_photo_pair": "A still image paired with its short motion video via `livePhotoVideoId`. Usually not a true duplicate — may warrant stacking, not deleting.",
+    "edge_case": "None of the above. Needs a human eye.",
+}
+
+
+def render_report(groups: list[dict], base_url: str) -> str:
+    total_groups = len(groups)
+    total_assets = sum(len(g.get("assets") or []) for g in groups)
+
+    buckets: dict[str, list[dict]] = defaultdict(list)
+    bucket_reclaim: dict[str, int] = defaultdict(int)
+    total_reclaim = 0
+
+    for g in groups:
+        b = classify(g)
+        buckets[b].append(g)
+        r = reclaim_bytes(g)
+        bucket_reclaim[b] += r
+        total_reclaim += r
+
+    def tier_totals(tier: str) -> tuple[int, int]:
+        count = sum(
+            len(buckets.get(b, []))
+            for b, t in BUCKET_CONFIDENCE.items()
+            if t == tier
+        )
+        reclaim = sum(
+            bucket_reclaim[b]
+            for b, t in BUCKET_CONFIDENCE.items()
+            if t == tier
+        )
+        return count, reclaim
+
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    lines: list[str] = []
+
+    lines.append("# Immich duplicate classification report")
+    lines.append("")
+    lines.append(f"- Generated: {now}")
+    lines.append(f"- Source: {base_url}")
+    lines.append(f"- Total duplicate groups: {total_groups:,}")
+    lines.append(f"- Total assets across groups: {total_assets:,}")
+    lines.append(
+        f"- Estimated reclaim if Immich's suggestions respected: "
+        f"{total_reclaim / 1024**3:.1f} GB"
+    )
+    lines.append("")
+
+    lines.append("## Actionable summary")
+    lines.append("")
+    for tier, _label in CONFIDENCE_TIERS:
+        count, reclaim = tier_totals(tier)
+        pct = (100 * count / total_groups) if total_groups else 0.0
+        lines.append(
+            f"- **{tier}**: {count:,} groups ({pct:.1f}%) · "
+            f"{reclaim / 1024**3:.1f} GB reclaim"
+        )
+    lines.append("")
+
+    lines.append("## Bucket breakdown by confidence tier")
+    lines.append("")
+
+    for tier, label in CONFIDENCE_TIERS:
+        tier_buckets = [b for b in BUCKETS if BUCKET_CONFIDENCE.get(b) == tier]
+        if not tier_buckets or all(not buckets.get(b) for b in tier_buckets):
+            continue
+        lines.append(f"### {label}")
+        lines.append("")
+        lines.append("| Bucket | Groups | % of groups | Reclaim (GB) |")
+        lines.append("|---|---:|---:|---:|")
+        for b in tier_buckets:
+            count = len(buckets.get(b, []))
+            pct = (100 * count / total_groups) if total_groups else 0.0
+            gb = bucket_reclaim[b] / 1024**3
+            lines.append(f"| {b} | {count:,} | {pct:.1f}% | {gb:.1f} |")
+        lines.append("")
+
+    lines.append("## What each bucket means")
+    lines.append("")
+    for b in BUCKETS:
+        desc = BUCKET_DESCRIPTIONS.get(b, "")
+        lines.append(f"- **{b}** — {desc}")
+    lines.append("")
+
+    lines.append("## Samples (first 3 groups per bucket)")
+    for b in BUCKETS:
+        samples = buckets.get(b, [])[:3]
+        if not samples:
+            continue
+        lines.append("")
+        lines.append(f"### {b}")
+        lines.append("")
+        for g in samples:
+            lines.append(
+                f"**group `{g.get('duplicateId', '?')}`** — "
+                f"{len(g.get('assets') or [])} assets"
+            )
+            lines.append("")
+            for a in g.get("assets") or []:
+                exif = a.get("exifInfo") or {}
+                size_mb = asset_size(a) / 1024**2
+                make = exif.get("make") or ""
+                model = exif.get("model") or ""
+                dims = f"{a.get('width', '?')}×{a.get('height', '?')}"
+                keep = (
+                    " **(suggested keep)**"
+                    if a.get("id") in (g.get("suggestedKeepAssetIds") or [])
+                    else ""
+                )
+                device = f"{make} {model}".strip()
+                device_part = f" · {device}" if device else ""
+                lines.append(
+                    f"- `{a.get('originalFileName', '?')}` · "
+                    f"{a.get('originalMimeType', '?')} · "
+                    f"{dims} · {size_mb:.1f} MB{device_part}{keep}"
+                )
+            lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+# --- main ---
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify Immich duplicate groups for easier bulk triage.",
+    )
+    parser.add_argument(
+        "--env",
+        default=".env",
+        help="Path to .env file (default: ./.env). Reads IMMICH_URL and IMMICH_API_KEY.",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Write the report to a file (default: stdout).",
+    )
+    parser.add_argument(
+        "--raw",
+        default=None,
+        help="Also dump the raw /duplicates response to this path for offline inspection.",
+    )
+    args = parser.parse_args(argv)
+
+    load_env(args.env)
+    base_url = os.environ.get("IMMICH_URL")
+    api_key = os.environ.get("IMMICH_API_KEY")
+    if not base_url or not api_key:
+        print(
+            "error: IMMICH_URL and IMMICH_API_KEY must be set "
+            "(copy .env.example to .env and fill them in)",
+            file=sys.stderr,
+        )
+        return 2
+
+    groups = fetch_duplicates(base_url, api_key)
+
+    if args.raw:
+        with open(args.raw, "w") as f:
+            json.dump(groups, f, indent=2)
+
+    report = render_report(groups, base_url)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(report)
+    else:
+        sys.stdout.write(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/immich-dedup/gallery.py
+++ b/tools/immich-dedup/gallery.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+immich-dedup gallery: visual spot-check companion to classify.py.
+
+Fetches duplicate groups, classifies them with the same rules as classify.py,
+samples N random groups per bucket, pulls a thumbnail for every asset in each
+sampled group, and writes a single self-contained HTML file with the
+thumbnails embedded as base64 data URLs.
+
+The goal is visual trust-building before running any destructive action.
+Open the HTML in a browser, scroll through each bucket's sample, verify that
+the highlighted keeper is the one you'd pick by eye. If every bucket's
+samples look right, you can proceed with confidence. If not, tune the rules
+or exclude that bucket from bulk-accept.
+
+Usage:
+    python3 gallery.py                       # gallery.html, 20 samples/bucket
+    python3 gallery.py --samples 50          # wider spot-check
+    python3 gallery.py --out review.html     # alternate output path
+    python3 gallery.py --size preview        # larger thumbnails (slower to fetch)
+
+No third-party Python dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import html
+import os
+import random
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+
+# Reuse classification logic from classify.py.
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import classify  # noqa: E402
+
+
+DEFAULT_SAMPLES_PER_BUCKET = 20
+DEFAULT_THUMBNAIL_SIZE = "thumbnail"  # options: thumbnail | preview | fullsize
+
+
+def fetch_thumbnail(base_url: str, api_key: str, asset_id: str,
+                    size: str = DEFAULT_THUMBNAIL_SIZE) -> tuple[bytes, str] | None:
+    """Return (bytes, content_type) for an asset thumbnail, or None on failure."""
+    url = (
+        f"{base_url.rstrip('/')}/api/assets/{asset_id}/thumbnail"
+        f"?size={size}"
+    )
+    req = urllib.request.Request(url, headers={"x-api-key": api_key})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+            content_type = resp.headers.get("Content-Type", "image/jpeg")
+            return data, content_type
+    except (urllib.error.URLError, urllib.error.HTTPError) as e:
+        print(f"  ! thumbnail fetch failed for {asset_id}: {e}", file=sys.stderr)
+        return None
+
+
+def data_uri(data: bytes, content_type: str) -> str:
+    return f"data:{content_type};base64,{base64.b64encode(data).decode('ascii')}"
+
+
+# -------- HTML rendering --------
+
+CSS = """
+:root {
+  --bg: #0f1115;
+  --panel: #161a21;
+  --text: #e5e7eb;
+  --muted: #8b95a7;
+  --border: #272c36;
+  --keep: #10b981;
+  --keep-dim: #065f46;
+  --loser: #6b7280;
+  --tier-high: #10b981;
+  --tier-medium: #f59e0b;
+  --tier-review: #ef4444;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2rem;
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg); color: var(--text);
+}
+h1 { margin: 0 0 1rem; font-size: 1.6rem; }
+.summary {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem;
+  margin-bottom: 2rem;
+}
+.tier-card {
+  padding: 1rem; background: var(--panel); border-radius: 8px;
+  border-left: 4px solid var(--border);
+}
+.tier-card.high { border-left-color: var(--tier-high); }
+.tier-card.medium { border-left-color: var(--tier-medium); }
+.tier-card.review { border-left-color: var(--tier-review); }
+.tier-card .label { color: var(--muted); font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.tier-card .count { font-size: 1.8rem; font-weight: 600; margin-top: 0.25rem; }
+.tier-card .reclaim { color: var(--muted); margin-top: 0.25rem; }
+h2 {
+  margin: 2.5rem 0 0.5rem; padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border); font-size: 1.2rem;
+}
+h2 .tier-pill {
+  display: inline-block; margin-left: 0.75rem;
+  padding: 0.15rem 0.5rem; border-radius: 10px;
+  font-size: 0.75rem; font-weight: 500; text-transform: uppercase;
+}
+.tier-pill.high { background: var(--keep-dim); color: var(--tier-high); }
+.tier-pill.medium { background: #78350f; color: var(--tier-medium); }
+.tier-pill.review { background: #7f1d1d; color: var(--tier-review); }
+.bucket-description {
+  color: var(--muted); font-size: 0.9rem; margin: 0 0 1rem;
+}
+.group {
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1rem;
+}
+.group-meta {
+  color: var(--muted); font-size: 0.8rem; margin-bottom: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.assets {
+  display: flex; flex-wrap: wrap; gap: 0.75rem;
+}
+.asset {
+  width: 220px; background: var(--bg); border: 2px solid var(--border);
+  border-radius: 4px; overflow: hidden; position: relative;
+}
+.asset.keeper { border-color: var(--keep); }
+.asset img {
+  display: block; width: 100%; height: 180px;
+  object-fit: cover; background: #000;
+}
+.asset .badge {
+  position: absolute; top: 0.4rem; left: 0.4rem;
+  padding: 0.15rem 0.5rem; border-radius: 3px;
+  font-size: 0.7rem; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.asset.keeper .badge { background: var(--keep); color: #000; }
+.asset:not(.keeper) .badge { background: var(--loser); color: #fff; opacity: 0.9; }
+.asset .meta { padding: 0.4rem 0.5rem; font-size: 0.75rem; line-height: 1.35; }
+.asset .filename {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.asset .dims { color: var(--muted); }
+.empty { color: var(--muted); font-style: italic; padding: 0.5rem 0; }
+"""
+
+
+def _fmt_bytes_gb(n: int) -> str:
+    return f"{n / 1024**3:.1f} GB"
+
+
+def render_gallery_html(groups: list[dict], base_url: str, api_key: str,
+                        samples_per_bucket: int, thumbnail_size: str,
+                        seed: int) -> str:
+    rng = random.Random(seed)
+
+    # Classify once, bucket once.
+    buckets: dict[str, list[dict]] = defaultdict(list)
+    bucket_reclaim: dict[str, int] = defaultdict(int)
+    for g in groups:
+        b = classify.classify(g)
+        buckets[b].append(g)
+        bucket_reclaim[b] += classify.reclaim_bytes(g)
+
+    def tier_totals(tier: str) -> tuple[int, int]:
+        count = sum(
+            len(buckets.get(b, []))
+            for b, t in classify.BUCKET_CONFIDENCE.items()
+            if t == tier
+        )
+        reclaim = sum(
+            bucket_reclaim[b]
+            for b, t in classify.BUCKET_CONFIDENCE.items()
+            if t == tier
+        )
+        return count, reclaim
+
+    lines: list[str] = []
+    lines.append("<!DOCTYPE html>")
+    lines.append('<html lang="en">')
+    lines.append("<head>")
+    lines.append('<meta charset="utf-8">')
+    lines.append(f"<title>Immich Dedup Review — {html.escape(base_url)}</title>")
+    lines.append(f"<style>{CSS}</style>")
+    lines.append("</head>")
+    lines.append("<body>")
+    lines.append("<h1>Immich duplicate review gallery</h1>")
+    lines.append(
+        f"<p class='bucket-description'>"
+        f"{len(groups):,} duplicate groups · "
+        f"{samples_per_bucket} random samples per bucket · "
+        f"{html.escape(base_url)}"
+        f"</p>"
+    )
+
+    # Top-level tier summary cards.
+    lines.append("<div class='summary'>")
+    for tier, _label in classify.CONFIDENCE_TIERS:
+        count, reclaim = tier_totals(tier)
+        lines.append(
+            f"<div class='tier-card {tier}'>"
+            f"<div class='label'>{tier}</div>"
+            f"<div class='count'>{count:,} groups</div>"
+            f"<div class='reclaim'>{_fmt_bytes_gb(reclaim)} reclaim</div>"
+            f"</div>"
+        )
+    lines.append("</div>")
+
+    # Per-bucket sections, ordered by tier then bucket order.
+    total_assets_to_fetch = 0
+    plan: list[tuple[str, list[dict]]] = []
+    for tier, _label in classify.CONFIDENCE_TIERS:
+        for b in classify.BUCKETS:
+            if classify.BUCKET_CONFIDENCE.get(b) != tier:
+                continue
+            pool = buckets.get(b, [])
+            if not pool:
+                continue
+            k = min(samples_per_bucket, len(pool))
+            sampled = rng.sample(pool, k)
+            plan.append((b, sampled))
+            total_assets_to_fetch += sum(
+                len(g.get("assets") or []) for g in sampled
+            )
+
+    print(
+        f"[gallery] fetching {total_assets_to_fetch} thumbnails "
+        f"across {sum(len(s) for _, s in plan)} groups…",
+        file=sys.stderr,
+    )
+
+    fetched = 0
+    for b, sampled in plan:
+        tier = classify.BUCKET_CONFIDENCE.get(b, "review")
+        total_in_bucket = len(buckets.get(b, []))
+        description = classify.BUCKET_DESCRIPTIONS.get(b, "")
+        lines.append(
+            f"<h2>{html.escape(b)} "
+            f"<span class='tier-pill {tier}'>{tier}</span>"
+            f"<span class='bucket-description' style='margin-left:0.75rem;font-weight:400;'>"
+            f"{len(sampled)} samples of {total_in_bucket:,}"
+            f"</span></h2>"
+        )
+        lines.append(f"<p class='bucket-description'>{html.escape(description)}</p>")
+
+        for g in sampled:
+            gid = html.escape(str(g.get("duplicateId", "?")))
+            asset_count = len(g.get("assets") or [])
+            lines.append("<div class='group'>")
+            lines.append(
+                f"<div class='group-meta'>group {gid} · {asset_count} assets</div>"
+            )
+            lines.append("<div class='assets'>")
+            keep_ids = set(g.get("suggestedKeepAssetIds") or [])
+            for a in g.get("assets") or []:
+                fetched += 1
+                if fetched % 50 == 0:
+                    print(
+                        f"[gallery] fetched {fetched}/{total_assets_to_fetch}",
+                        file=sys.stderr,
+                    )
+                is_keeper = a.get("id") in keep_ids
+                thumb = fetch_thumbnail(base_url, api_key, a["id"], thumbnail_size)
+                img_src = (
+                    data_uri(thumb[0], thumb[1])
+                    if thumb else
+                    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='180'><rect width='220' height='180' fill='%23222'/><text x='110' y='95' fill='%23888' font-family='sans-serif' font-size='13' text-anchor='middle'>no thumbnail</text></svg>"
+                )
+                exif = a.get("exifInfo") or {}
+                size_mb = (exif.get("fileSizeInByte") or 0) / 1024**2
+                dims = f"{a.get('width') or '?'}×{a.get('height') or '?'}"
+                filename = html.escape(a.get("originalFileName") or "?")
+                make_model = html.escape(
+                    f"{exif.get('make') or ''} {exif.get('model') or ''}".strip()
+                )
+                badge = "Keep" if is_keeper else "Trash"
+                klass = "asset keeper" if is_keeper else "asset"
+                lines.append(f"<div class='{klass}'>")
+                lines.append(f"<span class='badge'>{badge}</span>")
+                lines.append(f"<img src='{img_src}' loading='lazy'>")
+                lines.append("<div class='meta'>")
+                lines.append(f"<div class='filename' title='{filename}'>{filename}</div>")
+                lines.append(
+                    f"<div class='dims'>{dims} · {size_mb:.1f} MB</div>"
+                )
+                if make_model:
+                    lines.append(f"<div class='dims'>{make_model}</div>")
+                lines.append("</div>")  # .meta
+                lines.append("</div>")  # .asset
+            lines.append("</div>")  # .assets
+            lines.append("</div>")  # .group
+
+    print(f"[gallery] done — fetched {fetched} thumbnails", file=sys.stderr)
+
+    lines.append("</body>")
+    lines.append("</html>")
+    return "\n".join(lines) + "\n"
+
+
+# -------- main --------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Visual review gallery for Immich duplicate classification.",
+    )
+    parser.add_argument(
+        "--env", default=".env",
+        help="Path to .env file (default: ./.env).",
+    )
+    parser.add_argument(
+        "--out", default="gallery.html",
+        help="Output HTML path (default: gallery.html).",
+    )
+    parser.add_argument(
+        "--samples", type=int, default=DEFAULT_SAMPLES_PER_BUCKET,
+        help=f"Random sample size per bucket (default: {DEFAULT_SAMPLES_PER_BUCKET}).",
+    )
+    parser.add_argument(
+        "--size", default=DEFAULT_THUMBNAIL_SIZE,
+        choices=["thumbnail", "preview", "fullsize"],
+        help=f"Thumbnail size to request from Immich (default: {DEFAULT_THUMBNAIL_SIZE}).",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="Random seed for sample selection (default: 42, for reproducibility).",
+    )
+    args = parser.parse_args(argv)
+
+    classify.load_env(args.env)
+    base_url = os.environ.get("IMMICH_URL")
+    api_key = os.environ.get("IMMICH_API_KEY")
+    if not base_url or not api_key:
+        print(
+            "error: IMMICH_URL and IMMICH_API_KEY must be set",
+            file=sys.stderr,
+        )
+        return 2
+
+    groups = classify.fetch_duplicates(base_url, api_key)
+    html_out = render_gallery_html(
+        groups, base_url, api_key,
+        samples_per_bucket=args.samples,
+        thumbnail_size=args.size,
+        seed=args.seed,
+    )
+    with open(args.out, "w") as f:
+        f.write(html_out)
+    print(f"[gallery] wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/immich-dedup/tests/test_apply.py
+++ b/tools/immich-dedup/tests/test_apply.py
@@ -1,0 +1,165 @@
+"""Tests for apply.py group selection logic (no network)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PARENT = os.path.dirname(HERE)
+if PARENT not in sys.path:
+    sys.path.insert(0, PARENT)
+
+import apply  # noqa: E402
+import classify  # noqa: E402
+
+
+def _asset(**overrides):
+    base = {
+        "id": "asset-id",
+        "checksum": "abc",
+        "originalFileName": "IMG_0001.HEIC",
+        "originalMimeType": "image/heic",
+        "type": "IMAGE",
+        "width": 4032,
+        "height": 3024,
+        "fileCreatedAt": "2025-06-01T12:00:00.000Z",
+        "livePhotoVideoId": None,
+        "exifInfo": {
+            "make": "Apple", "model": "iPhone 16 Pro",
+            "fileSizeInByte": 4_000_000,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _heic_jpeg_group(gid="g1", keep="a"):
+    return {
+        "duplicateId": gid,
+        "assets": [
+            _asset(id="a", originalFileName="photo.heic",
+                   originalMimeType="image/heic"),
+            _asset(id="b", originalFileName="photo.jpg",
+                   originalMimeType="image/jpeg"),
+        ],
+        "suggestedKeepAssetIds": [keep],
+    }
+
+
+def _rendition_group(gid="g2"):
+    uuid = "add78468-93e5-442a-b241-2c412e48710d"
+    return {
+        "duplicateId": gid,
+        "assets": [
+            _asset(id="r1", originalFileName=f"{uuid}.jpeg",
+                   originalMimeType="image/jpeg"),
+            _asset(id="r2", originalFileName=f"{uuid}_1_105_c.jpeg",
+                   originalMimeType="image/jpeg"),
+            _asset(id="r3", originalFileName=f"{uuid}_4_5005_c.jpeg",
+                   originalMimeType="image/jpeg"),
+        ],
+        "suggestedKeepAssetIds": ["r1"],
+    }
+
+
+class ExpandBucketFilterTests(unittest.TestCase):
+    def test_single_bucket(self):
+        self.assertEqual(
+            apply.expand_bucket_filter(["rendition_set"], None),
+            {"rendition_set"},
+        )
+
+    def test_comma_separated(self):
+        self.assertEqual(
+            apply.expand_bucket_filter(["rendition_set,heic_jpeg_pair"], None),
+            {"rendition_set", "heic_jpeg_pair"},
+        )
+
+    def test_repeated_flag(self):
+        self.assertEqual(
+            apply.expand_bucket_filter(["burst", "screenshots"], None),
+            {"burst", "screenshots"},
+        )
+
+    def test_tier_expands_to_all_buckets_in_tier(self):
+        result = apply.expand_bucket_filter(None, "high")
+        # The high tier currently includes: heic_jpeg_pair, rendition_set,
+        # dominant_keeper. Assert the full set matches BUCKET_CONFIDENCE.
+        expected = {
+            b for b, t in classify.BUCKET_CONFIDENCE.items() if t == "high"
+        }
+        self.assertEqual(result, expected)
+
+    def test_bucket_and_tier_union(self):
+        result = apply.expand_bucket_filter(["burst"], "high")
+        expected = {b for b, t in classify.BUCKET_CONFIDENCE.items() if t == "high"}
+        expected.add("burst")
+        self.assertEqual(result, expected)
+
+    def test_empty(self):
+        self.assertEqual(apply.expand_bucket_filter(None, None), set())
+
+
+class SelectGroupsTests(unittest.TestCase):
+    def test_filter_to_specific_bucket(self):
+        groups = [_heic_jpeg_group("g1"), _rendition_group("g2")]
+        selected = apply.select_groups(groups, bucket_filter={"heic_jpeg_pair"})
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0][0], "heic_jpeg_pair")
+        self.assertEqual(selected[0][1]["duplicateId"], "g1")
+
+    def test_multiple_buckets_union(self):
+        groups = [_heic_jpeg_group("g1"), _rendition_group("g2")]
+        selected = apply.select_groups(
+            groups, bucket_filter={"heic_jpeg_pair", "rendition_set"}
+        )
+        self.assertEqual(len(selected), 2)
+
+    def test_limit_caps_output(self):
+        groups = [_rendition_group(f"g{i}") for i in range(10)]
+        selected = apply.select_groups(
+            groups, bucket_filter={"rendition_set"}, limit=3,
+        )
+        self.assertEqual(len(selected), 3)
+
+    def test_skips_groups_without_suggested_keeper(self):
+        g = _rendition_group("g1")
+        g["suggestedKeepAssetIds"] = []  # no suggestion
+        selected = apply.select_groups([g], bucket_filter={"rendition_set"})
+        self.assertEqual(selected, [])
+
+    def test_trash_ids_exclude_keeper(self):
+        g = _rendition_group("g1")
+        selected = apply.select_groups([g], bucket_filter={"rendition_set"})
+        self.assertEqual(len(selected), 1)
+        _, dto = selected[0]
+        self.assertEqual(dto["keepAssetIds"], ["r1"])
+        self.assertEqual(sorted(dto["trashAssetIds"]), ["r2", "r3"])
+
+    def test_resolve_dto_shape(self):
+        g = _heic_jpeg_group("g1", keep="a")
+        [(bucket, dto)] = apply.select_groups(
+            [g], bucket_filter={"heic_jpeg_pair"}
+        )
+        self.assertEqual(bucket, "heic_jpeg_pair")
+        self.assertEqual(set(dto.keys()),
+                         {"duplicateId", "keepAssetIds", "trashAssetIds"})
+        self.assertEqual(dto["duplicateId"], "g1")
+
+    def test_skips_when_all_assets_are_keepers(self):
+        # If suggested keepers covers every asset, there's nothing to trash.
+        g = _heic_jpeg_group("g1", keep="a")
+        g["suggestedKeepAssetIds"] = ["a", "b"]
+        selected = apply.select_groups([g], bucket_filter={"heic_jpeg_pair"})
+        self.assertEqual(selected, [])
+
+    def test_no_bucket_filter_selects_all_classifiable(self):
+        groups = [_heic_jpeg_group("g1"), _rendition_group("g2")]
+        selected = apply.select_groups(groups, bucket_filter=None)
+        self.assertEqual(len(selected), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/immich-dedup/tests/test_classify.py
+++ b/tools/immich-dedup/tests/test_classify.py
@@ -1,0 +1,331 @@
+"""Unit tests for the classification functions.
+
+These tests exercise pure logic — no network, no Immich. Run with:
+
+    python3 -m unittest discover -s tests -v
+
+from within the tool directory.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+# Make classify.py importable when running from this directory or the repo root.
+HERE = os.path.dirname(os.path.abspath(__file__))
+PARENT = os.path.dirname(HERE)
+if PARENT not in sys.path:
+    sys.path.insert(0, PARENT)
+
+import classify  # noqa: E402
+
+
+def _asset(**overrides):
+    """Build a minimal AssetResponseDto-shaped dict with overrides."""
+    base = {
+        "id": "00000000-0000-4000-8000-000000000000",
+        "checksum": "abc",
+        "originalFileName": "IMG_0001.HEIC",
+        "originalMimeType": "image/heic",
+        "type": "IMAGE",
+        "width": 4032,
+        "height": 3024,
+        "fileCreatedAt": "2025-06-01T12:00:00.000Z",
+        "livePhotoVideoId": None,
+        "exifInfo": {
+            "make": "Apple",
+            "model": "iPhone 16 Pro",
+            "fileSizeInByte": 4_000_000,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _group(assets, suggested=None, duplicate_id="group-1"):
+    return {
+        "duplicateId": duplicate_id,
+        "assets": assets,
+        "suggestedKeepAssetIds": suggested or [],
+    }
+
+
+class CanonicalStemTests(unittest.TestCase):
+    def test_strips_extension(self):
+        self.assertEqual(classify.canonical_stem("IMG_1234.HEIC"), "img_1234")
+
+    def test_strips_ios_rendition_suffix_four_number(self):
+        self.assertEqual(
+            classify.canonical_stem(
+                "ADD78468-93E5-442A-B241-2C412E48710D_1_105_c.jpeg"
+            ),
+            "add78468-93e5-442a-b241-2c412e48710d",
+        )
+
+    def test_strips_ios_rendition_suffix_five_number(self):
+        self.assertEqual(
+            classify.canonical_stem(
+                "ADD78468-93E5-442A-B241-2C412E48710D_4_5005_c.jpeg"
+            ),
+            "add78468-93e5-442a-b241-2c412e48710d",
+        )
+
+    def test_strips_ios_rendition_suffix_original_variant(self):
+        # _o = original-format rendition
+        self.assertEqual(
+            classify.canonical_stem(
+                "C1B35D14-ADBF-4348-8BEE-ACA696072B5B_1_102_o.jpeg"
+            ),
+            "c1b35d14-adbf-4348-8bee-aca696072b5b",
+        )
+
+    def test_strips_ios_rendition_suffix_adjusted_variant(self):
+        # _a = adjusted (edited) rendition
+        self.assertEqual(
+            classify.canonical_stem(
+                "EA8BE79F-2DA7-4200-B7A2-A37E9DE6EDA6_1_201_a.jpeg"
+            ),
+            "ea8be79f-2da7-4200-b7a2-a37e9de6eda6",
+        )
+
+    def test_strips_macos_copy_suffix(self):
+        self.assertEqual(classify.canonical_stem("IMG_1014 (2).PNG"), "img_1014")
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_heic_jpeg_pair(self):
+        g = _group([
+            _asset(id="a", originalFileName="photo1.heic",
+                   originalMimeType="image/heic"),
+            _asset(id="b", originalFileName="photo2.jpg",
+                   originalMimeType="image/jpeg"),
+        ])
+        self.assertEqual(classify.classify(g), "heic_jpeg_pair")
+
+    def test_live_photo_pair(self):
+        g = _group([
+            _asset(id="img", originalFileName="a.heic",
+                   type="IMAGE", livePhotoVideoId="vid"),
+            _asset(id="vid", originalFileName="a.mov", type="VIDEO",
+                   originalMimeType="video/quicktime"),
+        ])
+        self.assertEqual(classify.classify(g), "live_photo_pair")
+
+    def test_rendition_set_shared_uuid_stem(self):
+        uuid = "add78468-93e5-442a-b241-2c412e48710d"
+        g = _group([
+            _asset(id="a", originalFileName=f"{uuid}.jpeg",
+                   originalMimeType="image/jpeg"),
+            _asset(id="b", originalFileName=f"{uuid}_1_105_c.jpeg",
+                   originalMimeType="image/jpeg"),
+            _asset(id="c", originalFileName=f"{uuid}_4_5005_c.jpeg",
+                   originalMimeType="image/jpeg"),
+        ])
+        self.assertEqual(classify.classify(g), "rendition_set")
+
+    def test_rendition_set_partial_match_with_outlier(self):
+        uuid = "9cb5d371-a2be-4753-b9d9-6cb0ce2a2ac2"
+        g = _group([
+            _asset(id="a", originalFileName=f"{uuid}.jpeg",
+                   originalMimeType="image/jpeg"),
+            _asset(id="b", originalFileName="IMG_20181024_085750.jpg",
+                   originalMimeType="image/jpeg"),
+            _asset(id="c", originalFileName=f"{uuid}_1_105_c.jpeg",
+                   originalMimeType="image/jpeg"),
+        ])
+        self.assertEqual(classify.classify(g), "rendition_set")
+
+    def test_rendition_set_macos_copy_suffix(self):
+        g = _group([
+            _asset(id="a", originalFileName="IMG_1014.PNG",
+                   originalMimeType="image/png",
+                   exifInfo={"fileSizeInByte": 100_000}),
+            _asset(id="b", originalFileName="IMG_1014 (2).PNG",
+                   originalMimeType="image/png",
+                   exifInfo={"fileSizeInByte": 200_000}),
+        ])
+        self.assertEqual(classify.classify(g), "rendition_set")
+
+    def test_all_different_filenames_not_rendition_set(self):
+        # Sequential screenshots or unrelated photos with distinct names
+        # must NOT be classified as rendition_set.
+        g = _group([
+            _asset(id="a", originalFileName="IMG_5371.PNG",
+                   originalMimeType="image/png", exifInfo={"fileSizeInByte": 100_000}),
+            _asset(id="b", originalFileName="IMG_5372.PNG",
+                   originalMimeType="image/png", exifInfo={"fileSizeInByte": 100_000}),
+        ])
+        # Falls through to screenshots bucket.
+        self.assertEqual(classify.classify(g), "screenshots")
+
+    def test_screenshots(self):
+        g = _group([
+            _asset(
+                id="a", originalFileName="Screenshot_2025-06-01.png",
+                originalMimeType="image/png",
+                exifInfo={"fileSizeInByte": 1_000_000},
+            ),
+            _asset(
+                id="b", originalFileName="screenshot_2025-06-02.png",
+                originalMimeType="image/png",
+                exifInfo={"fileSizeInByte": 1_200_000},
+            ),
+        ])
+        self.assertEqual(classify.classify(g), "screenshots")
+
+    def test_burst_same_device_within_window(self):
+        g = _group([
+            _asset(id="a", originalFileName="IMG_1001.HEIC",
+                   fileCreatedAt="2025-06-01T12:00:00.000Z"),
+            _asset(id="b", originalFileName="IMG_1002.HEIC",
+                   fileCreatedAt="2025-06-01T12:00:02.000Z"),
+            _asset(id="c", originalFileName="IMG_1003.HEIC",
+                   fileCreatedAt="2025-06-01T12:00:04.500Z"),
+        ])
+        self.assertEqual(classify.classify(g), "burst")
+
+    def test_burst_different_devices_is_edge_case(self):
+        g = _group([
+            _asset(id="a", originalFileName="apple_shot.heic",
+                   exifInfo={"make": "Apple", "model": "iPhone 16 Pro",
+                             "fileSizeInByte": 4_000_000}),
+            _asset(id="b", originalFileName="sony_shot.arw",
+                   exifInfo={"make": "Sony", "model": "A7 IV",
+                             "fileSizeInByte": 5_000_000}),
+        ])
+        self.assertEqual(classify.classify(g), "edge_case")
+
+    def test_burst_outside_window_is_edge_case(self):
+        g = _group([
+            _asset(id="a", originalFileName="IMG_1001.HEIC",
+                   fileCreatedAt="2025-06-01T12:00:00.000Z"),
+            _asset(id="b", originalFileName="IMG_1002.HEIC",
+                   fileCreatedAt="2025-06-01T12:05:00.000Z"),
+        ])
+        self.assertEqual(classify.classify(g), "edge_case")
+
+    def test_single_asset_group_is_edge_case(self):
+        g = _group([_asset()])
+        self.assertEqual(classify.classify(g), "edge_case")
+
+
+class DominantKeeperTests(unittest.TestCase):
+    def test_keeper_holds_majority_of_bytes(self):
+        # Keeper 10MB, losers 2MB + 1MB + 0.5MB = 3.5MB total. Keeper dominates.
+        g = _group(
+            assets=[
+                _asset(id="keep", originalFileName="a.heic",
+                       exifInfo={"fileSizeInByte": 10_000_000}),
+                _asset(id="l1", originalFileName="b.heic",
+                       exifInfo={"fileSizeInByte": 2_000_000}),
+                _asset(id="l2", originalFileName="c.heic",
+                       exifInfo={"fileSizeInByte": 1_000_000}),
+                _asset(id="l3", originalFileName="d.heic",
+                       exifInfo={"fileSizeInByte": 500_000}),
+            ],
+            suggested=["keep"],
+        )
+        self.assertEqual(classify.classify(g), "dominant_keeper")
+
+    def test_keeper_has_much_more_pixels(self):
+        g = _group(
+            assets=[
+                _asset(id="keep", originalFileName="big.heic",
+                       width=4032, height=3024,
+                       exifInfo={"fileSizeInByte": 3_000_000}),
+                _asset(id="l1", originalFileName="small.heic",
+                       width=1024, height=768,
+                       exifInfo={"fileSizeInByte": 2_000_000}),
+            ],
+            suggested=["keep"],
+        )
+        self.assertEqual(classify.classify(g), "dominant_keeper")
+
+    def test_keeper_twice_filesize_of_largest_loser(self):
+        g = _group(
+            assets=[
+                _asset(id="keep", originalFileName="big.heic",
+                       width=2000, height=2000,
+                       exifInfo={"fileSizeInByte": 4_000_000}),
+                _asset(id="l1", originalFileName="mid.heic",
+                       width=2000, height=2000,
+                       exifInfo={"fileSizeInByte": 2_000_000}),
+            ],
+            suggested=["keep"],
+        )
+        self.assertEqual(classify.classify(g), "dominant_keeper")
+
+    def test_similar_sizes_fall_through_to_edge_case(self):
+        # Keeper 2.0MB, losers 1.5MB + 1.5MB. No rule fires:
+        #   - keeper (2.0) < sum losers (3.0)
+        #   - keeper pixels not 2× any loser
+        #   - keeper filesize not 2× largest loser
+        # Timestamps staggered beyond 5s so burst doesn't fire either.
+        g = _group(
+            assets=[
+                _asset(id="keep", originalFileName="aaa.heic",
+                       width=3000, height=2000,
+                       fileCreatedAt="2025-06-01T12:00:00.000Z",
+                       exifInfo={"make": "Apple", "model": "iPhone 16 Pro",
+                                 "fileSizeInByte": 2_000_000}),
+                _asset(id="l1", originalFileName="bbb.heic",
+                       width=3000, height=2000,
+                       fileCreatedAt="2025-06-01T12:00:02.000Z",
+                       exifInfo={"make": "Apple", "model": "iPhone 16 Pro",
+                                 "fileSizeInByte": 1_500_000}),
+                _asset(id="l2", originalFileName="ccc.heic",
+                       width=3000, height=2000,
+                       fileCreatedAt="2025-06-01T12:10:00.000Z",
+                       exifInfo={"make": "Apple", "model": "iPhone 16 Pro",
+                                 "fileSizeInByte": 1_500_000}),
+            ],
+            suggested=["keep"],
+        )
+        self.assertEqual(classify.classify(g), "edge_case")
+
+    def test_no_suggested_keeper_not_dominant(self):
+        # Without a suggestion, dominant_keeper can't fire. Same device + same
+        # time → burst fires first in the classify ordering.
+        g = _group(
+            assets=[
+                _asset(id="a", originalFileName="x.heic",
+                       exifInfo={"make": "Apple", "model": "iPhone 16 Pro",
+                                 "fileSizeInByte": 10_000_000}),
+                _asset(id="b", originalFileName="y.heic",
+                       exifInfo={"make": "Apple", "model": "iPhone 16 Pro",
+                                 "fileSizeInByte": 1_000_000}),
+            ],
+            suggested=[],
+        )
+        self.assertEqual(classify.classify(g), "burst")
+
+
+class ReclaimBytesTests(unittest.TestCase):
+    def test_reclaim_uses_suggested_keep(self):
+        g = _group(
+            assets=[
+                _asset(id="keep", exifInfo={"fileSizeInByte": 5_000_000}),
+                _asset(id="loser1", exifInfo={"fileSizeInByte": 3_000_000}),
+                _asset(id="loser2", exifInfo={"fileSizeInByte": 2_000_000}),
+            ],
+            suggested=["keep"],
+        )
+        self.assertEqual(classify.reclaim_bytes(g), 5_000_000)
+
+    def test_reclaim_fallback_keeps_largest(self):
+        g = _group(
+            assets=[
+                _asset(id="a", exifInfo={"fileSizeInByte": 1_000_000}),
+                _asset(id="b", exifInfo={"fileSizeInByte": 5_000_000}),
+                _asset(id="c", exifInfo={"fileSizeInByte": 2_000_000}),
+            ],
+            suggested=[],
+        )
+        # Keeps b (5MB), loses a (1MB) + c (2MB) = 3MB reclaim.
+        self.assertEqual(classify.reclaim_bytes(g), 3_000_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **immich-dedup tool** (`tools/immich-dedup/`) — community-ready Python CLI: `classify.py` (bucket breakdown), `gallery.py` (visual HTML review with embedded thumbnails), `apply.py` (bucket-filtered soft-delete execution with dry-run, retry, and JSONL log). Stdlib-only, MIT, 38 unit tests, external-facing README.
- **Plan 0002 Phase 2 execution** — ran the full dedup pass: 24,522 of 24,705 duplicate groups resolved to Immich trash. Classifier iterated from 0% → 97.1% high-confidence via `rendition_set` + `dominant_keeper` buckets + expanded iOS rendition suffix regex. 7-day soak period running before trash-empty.
- **Plan 0003 close** (zsh prompt setup) — shell/terminal configs snapshotted into `~/Atlas/config/{shell,terminal}/` via new `environment/sync-shell-config.sh` (copy-forward, `--check` mode) instead of symlinks. `folder-schemas/config.md` + `environment/shell-setup.md` added to document the model.
- **Plan 0004 exploration** — photo quality curation app, competitive landscape researched, build deferred.
- **Plan 0005 lifecycle + SSD schema** — per earlier-session work in commit 8e24a21.

## Test plan

- [x] `python3 -m unittest discover -s tools/immich-dedup/tests` — 38/38 passing
- [x] `classify.py` run against live Immich — 97.1% high-confidence classification across 24,705 groups
- [x] `gallery.py` run against live Immich — visual spot-check passed
- [x] `apply.py --bucket heic_jpeg_pair --confirm` canary — 8 groups resolved, restore verified
- [x] `apply.py --bucket rendition_set --confirm` at scale — crashed on batch 61 (socket.timeout), fixed via broadened except + retry + 300s timeout, resumed and completed
- [ ] 7-day trash soak — in progress, starts 2026-04-23
- [ ] Empty trash + record reclaimed GB — pending end of soak

🤖 Generated with [Claude Code](https://claude.com/claude-code)