### PR TITLE
Plan 0007 Phase 5: AM5 onboarding (mas pivot, apps-manual.md prune)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Claude Code local state
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Session scratch (should not be committed; processed by /session-end)
 docs/session-scratch.md

--- a/docs/plans/0007-am5-onboarding-and-harness-sync.md
+++ b/docs/plans/0007-am5-onboarding-and-harness-sync.md
@@ -1,6 +1,6 @@
 # Plan 0007 — AM5 onboarding & cross-device harness sync
 
-**Status:** In Progress — AM2 side of Milestone A complete (harness seeded at andrewhml/claude-harness, wrapper installed, Atlas claude-skills deprecated, issue #41 resolved). AM5 onboarding (Phase 5) and Milestone B (Brewfile + app inventory) pending.
+**Status:** Substantially complete — Milestones A + B exit criteria met on AM5 (harness cloned + wrapper installed; 6/6 plugins reinstalled; gh authenticated; Brewfile satisfied after mas regression carve-out → issue #53). Open: 1-week backup-retention window (delete AM2 pre-harness backup + Atlas `.claude-skills-deprecated-20260525T233115Z` around 2026-06-01).
 **planpong:** R4/10 | claude → codex | detail | 2P2 1P3 → 5P2 1P3 → 3P1 1P2 1P3 → 3P3 | Accepted: 14 | +273/-0 lines | 27m 11s | Approved after 4 rounds
 **Issues:** #43 (Claude config migration), #44 (gh auth on M5), #41 (NOTION_TOKEN secret remediation)
 **Created:** 2026-05-25 (re-spec'd same day after research-driven pivot)
@@ -730,6 +730,25 @@ Documentation update: append a paragraph to `environment/claude-setup.md` noting
 Records spec deviations and findings during actual execution.
 
 **2026-05-25 — Phase 1 (`d698f96`):** runbook (`environment/claude-setup.md`), per-machine setup script (`environment/setup-claude-secrets.sh`), `device-schemas/inventory.yaml` (new `repos:` section + `macbook-m5` device stub), `CLAUDE.md` (harness reference). Plan correction baked in: **`teams/` reclassified** from synced allowlist to per-machine exclude after Phase 2a audit confirmed it's per-project Claude Code teams-feature conversation transcripts (1.4 MB across 32 files), same category as `sessions/`.
+
+**2026-05-25 — Phase 3 (`2416c7a`):** Brewfile reconciled from `brew bundle dump` on AM2. Curated 34 entries across taps, CLI formulas, casks, mas entries, and npm globals with section comments.
+
+**2026-05-25 — Phase 4 (`15d3051`):** `environment/apps-manual.md` written covering 8 enumeration surfaces from AM2: AI clients, browsers, Adobe CC, comms, productivity, media, backup/sync, system/hw, editors/terminals, fonts, browser extensions, CLI tools outside brew, Login Items, LaunchAgents, preference panes, system extensions.
+
+**2026-05-25 — Phase 5 (AM5; uncommitted as of this entry, to be committed at session end):**
+
+- Phase 5a prereqs all green on AM5 (Drive desktop running with `~/Atlas/` populated; `gh` authenticated via SSH; brew + SSH to GitHub working; life-atlas repo up to date).
+- Phase 5b **failed first run** with 15 errors split into three classes:
+  1. **mas regression on macOS 26.5.** `mas install` now requires sudo (won't work non-interactively) and several ADAM IDs (Keynote 409183694, Meeter 1510445899, Numbers 409203825, Pages 409201541) return "No apps found in the App Store" despite the apps still existing. Verified by direct `mas install 803453959` (Slack) → identical sudo failure. **Remediation:** removed all 14 `mas` entries from `environment/Brewfile`; added a new "Mac App Store apps" section to `environment/apps-manual.md` documenting them by name + ADAM ID. Drift issue [#53](https://github.com/andrewhml/life-atlas/issues/53) filed; revisit Brewfile when a future Homebrew/mas/macOS release fixes the regression. Kept the `mas` formula in the Brewfile (`mas list` still works for audits).
+  2. **node not on PATH for non-interactive `brew bundle`.** `env: node: No such file or directory` for `@google/gemini-cli` and `vercel` npm globals — fnm initialization (`eval "$(fnm env --use-on-cd)"`) lives in `~/.zshrc` and isn't sourced by Bash. **Remediation:** installed the two npm globals directly with node on PATH via `npm install -g`.
+  3. (None — formulas + casks all installed cleanly.)
+  Post-remediation: `brew bundle check --verbose` → "The Brewfile's dependencies are satisfied" on AM5.
+- Phase 5c–5e effectively pre-completed: `~/.claude/` already a clone of `andrewhml/claude-harness` (on `9f4425a`); `claude` wrapper present at `~/.zshrc:26` (carried over by plan 0003's shell-config sync); no pre-mutation backup needed since no pre-clone state existed.
+- Phase 5f no-op: `secrets-manifest.txt` is comment-only (no current MCP server requires Keychain auth).
+- Phase 5g **prune + archive pass.** User triaged `apps-manual.md` against actual AM5 usage and dropped 17 entries: Copilot, Linear, GoToMeeting, Alfred 5, Sketch, Pencil, Calibre, Logitech G HUB, VIA (native — replaced by usevia.app web app), BeardedSpice, macFUSE, Airfoil + Airfoil Satellite, Sublime Text, iTerm, Warp Terminal, Transmit, GeForce NOW. Dropped entries relocated to a new **"Archived / no longer in use"** section (audit trail; preserves install pointers if needs change). Related housekeeping: removed macFUSE preference-pane row and Logitech G HUB system-extension row from the supporting tables. Active inventory remains the canonical "install on AM5" list.
+- Phase 5h plugin reinstall via `claude plugin` CLI (no need to drop into interactive Claude): user pre-ran most installs; smoke test surfaced two gaps — `frontend-design@claude-plugins-official` was missing on AM5 (lockfile lists it) and the `ouroboros` marketplace registration still lingered after Phase 2k removed the plugin. Installed `frontend-design`; removed `ouroboros` marketplace via `claude plugin marketplace remove ouroboros`. End state: 6/6 plugins per lockfile, 2/2 marketplaces (claude-plugins-official, ui-ux-pro-max-skill).
+- Phase 5i smoke test: harness on `origin/main` (`9f4425a`); `M settings.json` + `?? plugins/known_marketplaces.json` are expected churn (Claude rewrites + gitignored runtime file); `claude` wrapper loaded; `gh auth status` clean (closes #44); `brew bundle check` satisfied; `mcp.json` is `{}` so MCP smoke check vacuously passes; CLAUDE.md loads. Plugin "exercise each" criterion deferred to natural use given the installs reported success cleanly.
+- AM2 pre-harness backup + Atlas `.claude-skills-deprecated-20260525T233115Z` remain retained until ~2026-06-01 per the one-week safety window.
 
 **2026-05-25 — Phase 2a–2j (harness commits `fb8b9ee`, `9d2f17c`, `9f4425a`; life-atlas branch `feat/plan-0007-execution`):**
 

--- a/environment/Brewfile
+++ b/environment/Brewfile
@@ -26,7 +26,7 @@ brew "powerlevel10k"             # zsh theme (plan 0003)
 brew "git"                       # newer git than Xcode CLT
 brew "gh"                        # GitHub CLI (issues, PRs, label setup per CLAUDE.md)
 brew "fnm"                       # Fast Node Manager (sources the npm globals declared below)
-brew "mas"                       # Mac App Store CLI (powers the `mas` entries below)
+brew "mas"                       # Mac App Store CLI (`mas list` still useful; see note below re: `mas install`)
 brew "gitleaks"                  # secret scanner (plan 0007 Phase 2f)
 
 # ── CLI: modern unix replacements ─────────────────────────────────
@@ -74,23 +74,16 @@ brew "haimgel/tools/display_switch"  # watches USB connect/disconnect → switch
 cask "font-meslo-lg-nerd-font"   # required for p10k icons (plan 0003)
 cask "ghostty"                   # terminal emulator (plan 0003)
 
-# ── App Store apps (via mas) ──────────────────────────────────────
-# To find an app's id:  mas search "<name>"
-# To install/upgrade:    `brew bundle` (mas honors these entries)
-mas "Blackmagic Disk Speed Test", id: 425264550
-mas "Fantastical",                id: 975937182
-mas "GarageBand",                 id: 682658836
-mas "Harvest",                    id: 506189836
-mas "iMovie",                     id: 408981434
-mas "Keynote",                    id: 409183694
-mas "Meeter",                     id: 1510445899
-mas "NordVPN",                    id: 905953485
-mas "Numbers",                    id: 409203825
-mas "Pages",                      id: 409201541
-mas "Paprika Recipe Manager 3",   id: 1303222628
-mas "Shazam",                     id: 897118787
-mas "Slack",                      id: 803453959
-mas "The Unarchiver",             id: 425424353
+# ── App Store apps ────────────────────────────────────────────────
+# `mas install` is broken on macOS 26.5 (requires sudo + several ADAM IDs return
+# "No apps found"). Mac App Store apps are now installed manually via the App
+# Store app and documented in environment/apps-manual.md. `mas list` (above) is
+# still useful for auditing what's installed.
+#
+# Removed from this Brewfile (2026-05-25 during AM5 onboarding): Blackmagic Disk
+# Speed Test, Fantastical, GarageBand, Harvest, iMovie, Keynote, Meeter,
+# NordVPN, Numbers, Pages, Paprika Recipe Manager 3, Shazam, Slack, The
+# Unarchiver. See apps-manual.md > Mac App Store apps.
 
 # ── NPM globals (via Brewfile's `npm` syntax; requires fnm-managed node) ──
 npm "@google/gemini-cli"         # Gemini CLI

--- a/environment/apps-manual.md
+++ b/environment/apps-manual.md
@@ -4,7 +4,9 @@ Apps and parity-required items on AM2 that the Brewfile does NOT install. Walk t
 
 **Inventory captured 2026-05-25 (host=AM2, M2 Pro) during plan 0007 Phase 4** from 8 enumeration surfaces: `/Applications`, `mas list` (already in Brewfile), Login Items, LaunchAgents, fonts, browser extensions, preference panes / system extensions, CLI tools outside brew.
 
-Anything in [`environment/Brewfile`](Brewfile) is **not** repeated here. That includes: all 14 App Store apps (via `mas`), `font-meslo-lg-nerd-font`, `ghostty`, `display_switch` + `m1ddc`, all CLI formulas, and the 4 npm globals (`@google/gemini-cli`, `@openai/codex`, `planpong`, `vercel`).
+Anything in [`environment/Brewfile`](Brewfile) is **not** repeated here. That includes: `font-meslo-lg-nerd-font`, `ghostty`, `display_switch` + `m1ddc`, all CLI formulas, and the 4 npm globals (`@google/gemini-cli`, `@openai/codex`, `planpong`, `vercel`).
+
+Mac App Store apps live in the "Mac App Store apps" section below — they used to live in the Brewfile under `mas`, but `mas install` is broken on macOS 26.5 (requires sudo + several ADAM IDs return "No apps found"). Install MAS apps via the App Store GUI.
 
 ---
 
@@ -24,11 +26,6 @@ Anything in [`environment/Brewfile`](Brewfile) is **not** repeated here. That in
 - **Install:** https://openai.com/chatgpt/download
 - **Purpose:** OpenAI ChatGPT desktop client
 - **Setup notes:** Sign in.
-
-### Copilot.app
-- **Install:** Microsoft Store / https://copilot.microsoft.com
-- **Purpose:** Microsoft Copilot desktop
-- **Setup notes:** Sign in with Microsoft account.
 
 ---
 
@@ -85,10 +82,6 @@ LaunchAgents auto-installed by CC: `com.adobe.AdobeCreativeCloud`, `com.adobe.Ad
 - **Install:** https://sparkmailapp.com/
 - **Setup notes:** Sign in to recover account list.
 
-### Linear
-- **Install:** https://linear.app/download
-- **Setup notes:** Sign in to workspace.
-
 ### Notion
 - **Install:** https://www.notion.so/desktop
 - **Setup notes:** Sign in.
@@ -97,10 +90,6 @@ LaunchAgents auto-installed by CC: `com.adobe.AdobeCreativeCloud`, `com.adobe.Ad
 - **Install:** https://zoom.us/download
 - **Setup notes:** Sign in. (`us.zoom.updater.gui.501.*` LaunchAgents come with the app.)
 
-### GoToMeeting
-- **Install:** https://www.gotomeeting.com (only install if a specific meeting requires it)
-- **Setup notes:** Optional — used rarely.
-
 ---
 
 ## Productivity
@@ -108,14 +97,6 @@ LaunchAgents auto-installed by CC: `com.adobe.AdobeCreativeCloud`, `com.adobe.Ad
 ### Raycast
 - **Install:** https://www.raycast.com/
 - **Setup notes:** Sign in for cloud sync of snippets, scripts, extensions. (Login Item.)
-
-### Alfred 5
-- **Install:** https://www.alfredapp.com/
-- **Setup notes:** If you have a Powerpack license, sign in to enable advanced features. Configure preferences sync to a cloud folder if cross-machine syncing is desired.
-
-### Sketch
-- **Install:** https://www.sketch.com/download/mac
-- **Setup notes:** Sign in. Workspace projects sync via Sketch Cloud.
 
 ### Figma
 - **Install:** https://www.figma.com/downloads/
@@ -128,10 +109,6 @@ LaunchAgents auto-installed by CC: `com.adobe.AdobeCreativeCloud`, `com.adobe.Ad
 ### OmmWriter
 - **Install:** App Store or https://ommwriter.com
 - **Setup notes:** Distraction-free writing.
-
-### Pencil (HTML5 mockups)
-- **Install:** https://pencil.evolus.vn/
-- **Setup notes:** Standalone.
 
 ### Screen Studio
 - **Install:** https://screen.studio/
@@ -164,10 +141,6 @@ LaunchAgents auto-installed by CC: `com.adobe.AdobeCreativeCloud`, `com.adobe.Ad
 ### VLC
 - **Install:** https://www.videolan.org/vlc/
 - **Setup notes:** Standalone media player; covers what QuickTime can't.
-
-### Calibre
-- **Install:** https://calibre-ebook.com/download_osx
-- **Setup notes:** eBook management. Library path: confirm post-install (likely `~/Documents/Calibre Library/` or similar).
 
 ---
 
@@ -217,30 +190,8 @@ LaunchAgents auto-installed by CC: `com.adobe.AdobeCreativeCloud`, `com.adobe.Ad
 - **Purpose:** Logitech device configuration (mouse, keyboard, etc.)
 - **Setup notes:** Installs `com.logi.optionsplus.plist` + `com.logitech.LogiRightSight.Agent.plist` LaunchAgents.
 
-### Logitech G HUB (gaming peripherals)
-- **Install:** https://www.logitechg.com/en-us/innovation/g-hub.html
-- **Purpose:** Manages G-series peripherals; provides the `com.logi.ghub.hidfilter` driver extension.
-- **Setup notes:** Approve the driver extension in System Settings after install. Currently shows "activated waiting for user" on AM2 — same gate exists on AM5.
-
 ### VIA (mechanical keyboard programmer)
-- **Install:** https://usevia.app/ (web app) or https://github.com/the-via/releases (native)
-- **Purpose:** Re-flash keymap layers on QMK/VIA-compatible keyboards
-- **Setup notes:** Standalone.
-
-### BeardedSpice
-- **Install:** https://github.com/beardedspice/beardedspice
-- **Purpose:** Bridges macOS media keys to web players (YouTube, etc.)
-- **Setup notes:** Allow Accessibility permission.
-
-### Airfoil + Airfoil Satellite
-- **Install:** https://rogueamoeba.com/airfoil/ (paid app; license)
-- **Purpose:** Stream audio from Mac to AirPlay receivers / other Macs
-- **Setup notes:** Sign in / license key.
-
-### macFUSE
-- **Install:** https://osxfuse.github.io/
-- **Purpose:** Filesystem-in-userspace framework (for mounting NAS shares as macOS filesystems beyond SMB/AFP, or for Transmit)
-- **Setup notes:** System extension; reboot required after install. Approve in System Settings.
+- **Use:** https://usevia.app/ — web app, no install. Re-flashes keymap layers on QMK/VIA-compatible keyboards directly in the browser via WebHID.
 
 ---
 
@@ -249,32 +200,6 @@ LaunchAgents auto-installed by CC: `com.adobe.AdobeCreativeCloud`, `com.adobe.Ad
 ### Visual Studio Code
 - **Install:** https://code.visualstudio.com/ (or `brew install --cask visual-studio-code` if you want to bring it into brew management)
 - **Setup notes:** Sign in to Settings Sync (Microsoft account) for extensions + settings. Issue #48 in life-atlas tracks the long-term VS Code sync strategy.
-
-### Sublime Text
-- **Install:** https://www.sublimetext.com/download (+ license)
-- **Setup notes:** License key.
-
-### iTerm
-- **Install:** https://iterm2.com/ (you also have Ghostty via brew + Warp; iTerm is third)
-- **Setup notes:** Standalone. Optional given Ghostty + Warp.
-
-### Warp Terminal
-- **Install:** https://www.warp.dev/
-- **Setup notes:** Sign in. Note: harness's `claude` wrapper runs in any terminal.
-
-### Transmit
-- **Install:** https://panic.com/transmit/ (+ license)
-- **Purpose:** FTP/SFTP/S3/etc. client from Panic
-- **Setup notes:** License key.
-
----
-
-## Gaming / streaming
-
-### GeForce NOW
-- **Install:** https://www.nvidia.com/en-us/geforce-now/download/
-- **Purpose:** Cloud gaming
-- **Setup notes:** Sign in to Nvidia account.
 
 ---
 
@@ -343,12 +268,6 @@ These auto-launch at login on AM2. Most are set up automatically by their parent
 
 ---
 
-## Preference panes
-
-- **macFUSE.prefPane** at `/Library/PreferencePanes/` — see macFUSE entry in System / hardware section above.
-
----
-
 ## System extensions (need approval in System Settings after install)
 
 Approval prompt appears the first time the parent app launches; usually a one-time gate.
@@ -356,13 +275,74 @@ Approval prompt appears the first time the parent app launches; usually a one-ti
 | Extension | Parent app | State on AM2 |
 |---|---|---|
 | Tailscale Network Extension | Tailscale.app | activated enabled |
-| Logitech G HUB HID Driver Extension | Logi G HUB | activated, **waiting for user** approval |
 | OBS Virtual Camera | OBS Studio | activated enabled |
+
+---
+
+## Mac App Store apps
+
+These used to be `mas` entries in the Brewfile. As of 2026-05-25 they're documented here instead because `mas install` is broken on macOS 26.5 (requires sudo + several ADAM IDs return "No apps found"). Install via the App Store GUI — search by name, click Get/Install.
+
+| App | ADAM ID | Notes |
+|---|---|---|
+| Blackmagic Disk Speed Test | 425264550 | |
+| Fantastical | 975937182 | Calendar (paid) |
+| GarageBand | 682658836 | |
+| Harvest | 506189836 | Time tracking (paid) |
+| iMovie | 408981434 | |
+| Keynote | 409183694 | (Note: "Keynote Creator Studio" is a separate Apple app already on AM5; install Keynote proper only if you specifically need iWork.) |
+| Meeter | 1510445899 | Auto-launches video calls. Login Item — enable in Meeter preferences. |
+| NordVPN | 905953485 | Login Item — enable in NordVPN preferences. Vendor-direct download also works (https://nordvpn.com). |
+| Numbers | 409203825 | See Keynote note. |
+| Pages | 409201541 | See Keynote note. |
+| Paprika Recipe Manager 3 | 1303222628 | Paid app. |
+| Shazam | 897118787 | |
+| Slack | 803453959 | Vendor-direct download also works (https://slack.com/downloads/mac). |
+| The Unarchiver | 425424353 | |
+
+---
+
+## Archived / no longer in use
+
+Apps that were on AM2 but are NOT being brought forward to AM5. Kept here as an audit trail — if a future need surfaces, the install pointer is already documented.
+
+Pruned 2026-05-25 during plan 0007 Phase 5 AM5 onboarding.
+
+### AI clients
+- **Copilot.app** — Microsoft Copilot desktop. Install: Microsoft Store / https://copilot.microsoft.com.
+
+### Communication
+- **Linear** — workspace task tracker. Install: https://linear.app/download.
+- **GoToMeeting** — meeting client; was kept only for the rare meeting that required it. Install: https://www.gotomeeting.com.
+
+### Productivity
+- **Alfred 5** — launcher; superseded by Raycast. Install: https://www.alfredapp.com/ (Powerpack license if upgrading).
+- **Sketch** — design tool; superseded by Figma. Install: https://www.sketch.com/download/mac.
+- **Pencil (HTML5 mockups)** — wireframing. Install: https://pencil.evolus.vn/.
+
+### Media / photo / video
+- **Calibre** — eBook management. Install: https://calibre-ebook.com/download_osx.
+
+### System / hardware
+- **Logitech G HUB** — G-series peripheral configuration; carried a "waiting for user" driver-extension gate on AM2 and isn't needed without G-series gear. Install: https://www.logitechg.com/en-us/innovation/g-hub.html.
+- **VIA (native)** — replaced by the **usevia.app** web app (see System / hardware section above). Native release: https://github.com/the-via/releases.
+- **BeardedSpice** — media-key bridge to web players. Install: https://github.com/beardedspice/beardedspice.
+- **Airfoil + Airfoil Satellite** — Mac → AirPlay audio streaming (paid). Install: https://rogueamoeba.com/airfoil/.
+- **macFUSE** — filesystem-in-userspace; was a dependency for Transmit-style mounts. Install: https://osxfuse.github.io/.
+
+### Editors / terminals
+- **Sublime Text** — superseded by VS Code. Install: https://www.sublimetext.com/download (+ license).
+- **iTerm** — superseded by Ghostty (+ Warp historically). Install: https://iterm2.com/.
+- **Warp Terminal** — superseded by Ghostty. Install: https://www.warp.dev/.
+- **Transmit** — FTP/SFTP client (paid); no current need. Install: https://panic.com/transmit/.
+
+### Gaming / streaming
+- **GeForce NOW** — cloud gaming. Install: https://www.nvidia.com/en-us/geforce-now/download/.
 
 ---
 
 ## Notes / things to revisit
 
 - `ai.hermes.gateway.plist` and `com.dreamhome.sweepstakes.plist` LaunchAgents: investigate or remove before AM5 onboarding to avoid carrying cruft.
-- Logi G HUB driver extension is "waiting for user" on AM2 — approve next time you're in System Settings; same gate will exist on AM5.
 - Spark Desktop's cask was renamed `spark` → `spark-app` (note from old Brewfile); use `spark-app` if you ever cask it.
+- `mas install` regression on macOS 26.5 is tracked as a life-atlas drift issue (#53); consider revisiting the Brewfile if a future Homebrew/mas release fixes it.


### PR DESCRIPTION
## Summary

Completes plan 0007 Phase 5 — AM5 onboarding. Closes #43 (Claude harness on AM5) and #44 (gh auth on M5). Refs #53 (mas regression on macOS 26.5).

- **Brewfile**: removed all 14 `mas` entries — `mas install` is broken on macOS 26.5 (sudo requirement + "No apps found" on several ADAM IDs). Kept the `mas` formula for `mas list` audits. See #53.
- **apps-manual.md**: added a "Mac App Store apps" section absorbing the 14 mas refugees; pruned 17 unused entries (Copilot, Linear, GoToMeeting, Alfred 5, Sketch, Pencil, Calibre, Logitech G HUB, VIA native, BeardedSpice, macFUSE, Airfoil, Sublime Text, iTerm, Warp Terminal, Transmit, GeForce NOW) into a new "Archived / no longer in use" section preserving install pointers as an audit trail; tightened the preference-panes + system-extensions tables accordingly.
- **plan 0007**: status flipped to *Substantially complete*; execution log records Phases 3, 4, and 5 — Brewfile reconciliation, apps-manual.md authoring, mas pivot, plugin reinstall (`frontend-design` fill-in + `ouroboros` marketplace cleanup), and the 5i smoke test.
- **.gitignore**: added `.claude/scheduled_tasks.lock` (Claude Code runtime state).

## Test plan

- [x] `brew bundle check --verbose` passes on AM5 (post-mas-pivot)
- [x] `~/.claude/` clone clean against `origin/main` at `9f4425a`
- [x] `claude` wrapper loaded from `~/.zshrc:26`
- [x] `gh auth status` clean on AM5 (closes #44)
- [x] 6/6 plugins installed per `installed_plugins.lock.json`; 2/2 marketplaces (claude-plugins-official, ui-ux-pro-max-skill); `ouroboros` marketplace removed
- [x] `mcp.json` is `{}` — no MCP server requires auth (vacuous MCP smoke pass)
- [x] CLAUDE.md, statusline, skills, commands all load
- [ ] **Manual** — delete AM2 pre-harness backup + Atlas `.claude-skills-deprecated-20260525T233115Z` around 2026-06-01 (1-week safety window)