### PR TITLE
Brewfile: move Slack from App Store to vendor cask

### DIFF
--- a/environment/Brewfile
+++ b/environment/Brewfile
@@ -81,6 +81,7 @@ brew "waydabber/betterdisplay/betterdisplaycli"  # CLI invoked by display_switch
 cask "font-meslo-lg-nerd-font"   # required for p10k icons (plan 0003)
 cask "ghostty"                   # terminal emulator (plan 0003)
 cask "mole-app"                  # GUI version of `brew "mole"` (same upstream project, tw93/Mole)
+cask "slack"                     # vendor cask; replaces App Store install (auto-updates without App Store)
 
 # ── App Store apps ────────────────────────────────────────────────
 # `mas install` is broken on macOS 26.5 (requires sudo + several ADAM IDs return
@@ -90,8 +91,10 @@ cask "mole-app"                  # GUI version of `brew "mole"` (same upstream p
 #
 # Removed from this Brewfile (2026-05-25 during AM5 onboarding): Blackmagic Disk
 # Speed Test, Fantastical, GarageBand, Harvest, iMovie, Keynote, Meeter,
-# NordVPN, Numbers, Pages, Paprika Recipe Manager 3, Shazam, Slack, The
-# Unarchiver. See apps-manual.md > Mac App Store apps.
+# NordVPN, Numbers, Pages, Paprika Recipe Manager 3, Shazam, The Unarchiver.
+# See apps-manual.md > Mac App Store apps.
+# (Slack was in this list originally but moved back to a vendor cask above on
+# 2026-05-26 — see `cask "slack"`.)
 
 # ── NPM globals (via Brewfile's `npm` syntax; requires fnm-managed node) ──
 npm "@google/gemini-cli"         # Gemini CLI

--- a/environment/apps-manual.md
+++ b/environment/apps-manual.md
@@ -303,8 +303,9 @@ These used to be `mas` entries in the Brewfile. As of 2026-05-25 they're documen
 | Pages | 409201541 | See Keynote note. |
 | Paprika Recipe Manager 3 | 1303222628 | Paid app. |
 | Shazam | 897118787 | |
-| Slack | 803453959 | Vendor-direct download also works (https://slack.com/downloads/mac). |
 | The Unarchiver | 425424353 | |
+
+Slack was previously listed here; moved to `cask "slack"` in the Brewfile on 2026-05-26 so it auto-updates without the App Store.
 
 ---
 


### PR DESCRIPTION
## Summary
- Slack now installs via `brew install --cask slack` rather than the Mac App Store
- Removed from `apps-manual.md`'s App Store table; pointer left explaining the move
- Updated the prior "Removed from this Brewfile" comment block

Unrelated to plan 0009 — chore from earlier in session.

## Test plan
- [ ] Verify `brew bundle check --verbose` shows slack as satisfied (after merge, on AM2 or AM5)
- [ ] Confirm Slack still launches and auto-updates